### PR TITLE
feat: add new filter in aws ec2 describe-instances command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ List EC2 instances by filtering by tag:name value with queries to display some r
 ```shell
 aws ec2 describe-instances \
   --filters "Name=tag:Name,Values=<instance-name>" \
+  --filters "Name=instance-state-name,Values=<instance-state>" \
   --query "reverse(sort_by(Reservations[*].Instances[].{ID:InstanceId,Type:InstanceType,Status:State.Name,Init:LaunchTime,EC2Name:Tags[?Key == 'Name'].Value | [0]} &Init))" \
   --output table
 ```


### PR DESCRIPTION
New filter for the aws ec2 describe-instances command:
- **--filters "Name=instance-state-name,Values=(pending | running | shutting-down | terminated | stopping | stopped )"**

Source: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html