### PR TITLE
docs: add Databases section with RDS deletion guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A personal wiki of AWS knowledge. CLI commands, practical tips, and lessons lear
   - [STS](./cli/sts.md)
   - [SSO](./cli/sso.md)
   - [Login](./cli/login.md)
+- [Databases](#databases)
+  - [RDS Deletion](./databases/rds-deletion.md)
 - [AWS Developer Tools](#aws-developer-tools)
   - [Overview](./developer-tools/README.md)
   - [CodeCommit](./developer-tools/codecommit/README.md)
@@ -35,6 +37,14 @@ A personal wiki of AWS knowledge. CLI commands, practical tips, and lessons lear
 ## CLI
 
 AWS CLI commands for various AWS services.
+
+---
+
+## Databases
+
+Operational guides for AWS database services.
+
+- [RDS Deletion](./databases/rds-deletion.md) — considerations and checklist for deleting an RDS instance.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A personal wiki of AWS knowledge. CLI commands, practical tips, and lessons lear
   - [SSO](./cli/sso.md)
   - [Login](./cli/login.md)
 - [Databases](#databases)
+  - [Overview](./databases/README.md)
   - [RDS Deletion](./databases/rds-deletion.md)
 - [AWS Developer Tools](#aws-developer-tools)
   - [Overview](./developer-tools/README.md)
@@ -43,6 +44,8 @@ AWS CLI commands for various AWS services.
 ## Databases
 
 Operational guides for AWS database services.
+
+See [databases/README.md](./databases/README.md) for the section index.
 
 - [RDS Deletion](./databases/rds-deletion.md) — considerations and checklist for deleting an RDS instance.
 

--- a/databases/README.md
+++ b/databases/README.md
@@ -1,0 +1,11 @@
+# Databases
+
+Operational guides for AWS database services.
+
+## Guides
+
+- [RDS Deletion](./rds-deletion.md) — considerations and checklist for deleting a manually-created RDS instance
+
+## Related Scripts
+
+- [`scripts/rds-modify-snapshot.sh`](../scripts/rds-modify-snapshot.sh) — batch-modify RDS DB snapshot option groups

--- a/databases/rds-deletion.md
+++ b/databases/rds-deletion.md
@@ -1,0 +1,117 @@
+# RDS Instance Deletion
+
+Deleting an RDS instance is a permanent action. Once deleted, the instance and its automated backups are gone. This document covers the considerations you should take before proceeding with the deletion of an RDS instance.
+
+## Pre-Deletion Checklist
+
+Verify the instance is not in use by checking active connections and application configurations:
+```shell
+aws rds describe-db-instances --db-instance-identifier <INSTANCE_ID> \
+  --query 'DBInstances[0].DBInstanceStatus'
+```
+
+Check if the instance is managed by infrastructure-as-code (CloudFormation, Terraform, CDK). If so, delete it through the IaC tool instead of manually:
+```shell
+# CloudFormation
+aws cloudformation list-stack-resources --stack-name <STACK_NAME>
+
+# Terraform
+terraform state list | grep rds
+```
+
+Check for read replicas. These must be deleted before the primary instance. Note that read replicas require `--skip-final-snapshot` when deleting:
+```shell
+aws rds describe-db-instances --db-instance-identifier <INSTANCE_ID> \
+  --query 'DBInstances[0].ReadReplicaDBInstanceIdentifiers'
+```
+
+Check if deletion protection is enabled and disable it if needed:
+```shell
+# Check
+aws rds describe-db-instances --db-instance-identifier <INSTANCE_ID> \
+  --query 'DBInstances[0].DeletionProtection'
+
+# Disable
+aws rds modify-db-instance --db-instance-identifier <INSTANCE_ID> \
+  --no-deletion-protection --apply-immediately
+```
+
+Confirm the instance was not created from a snapshot (useful to know for rollback purposes):
+```shell
+aws rds describe-db-instances --db-instance-identifier <INSTANCE_ID> \
+  --query 'DBInstances[0].SnapshotIdentifier'
+```
+
+Check if the instance is in a failure state. Instances with status `failed`, `incompatible-restore`, or `incompatible-network` can only be deleted with `--skip-final-snapshot` (no final snapshot will be created):
+```shell
+aws rds describe-db-instances --db-instance-identifier <INSTANCE_ID> \
+  --query 'DBInstances[0].DBInstanceStatus'
+```
+
+Verify there are no dependent resources such as applications, Lambda functions, CloudWatch alarms, or DNS records pointing to the instance endpoint.
+
+## Snapshots
+
+### Manual vs Automated Snapshots
+
+- **Automated snapshots** are taken automatically by RDS on a schedule. They are deleted when the instance is deleted.
+- **Manual snapshots** are created explicitly. They persist after the instance is deleted.
+
+When you delete an instance, RDS creates a final manual snapshot by default. You must explicitly pass `--skip-final-snapshot` to skip it. In production, always keep the default behavior (don't skip it).
+
+### Review Existing Snapshots
+
+List all snapshots for the instance:
+```shell
+aws rds describe-db-snapshots --db-instance-identifier <INSTANCE_ID> \
+  --query 'DBSnapshots[*].[DBSnapshotIdentifier,SnapshotType,Status,SnapshotCreateTime]' \
+  --output table
+```
+
+Filter by snapshot type:
+```shell
+# Manual snapshots only
+aws rds describe-db-snapshots --db-instance-identifier <INSTANCE_ID> \
+  --snapshot-type manual \
+  --query 'DBSnapshots[*].[DBSnapshotIdentifier,Status,SnapshotCreateTime]' \
+  --output table
+
+# Automated snapshots only
+aws rds describe-db-snapshots --db-instance-identifier <INSTANCE_ID> \
+  --snapshot-type automated \
+  --query 'DBSnapshots[*].[DBSnapshotIdentifier,Status,SnapshotCreateTime]' \
+  --output table
+```
+
+### Create a Final Snapshot
+
+```shell
+aws rds create-db-snapshot \
+  --db-instance-identifier <INSTANCE_ID> \
+  --db-snapshot-identifier <SNAPSHOT_NAME>
+```
+
+Wait for the snapshot to be available before deleting the instance:
+```shell
+aws rds wait db-snapshot-available --db-snapshot-identifier <SNAPSHOT_NAME>
+```
+
+### Snapshot Retention
+
+Manual snapshots persist indefinitely and incur storage costs. Set a reminder to delete them when no longer needed:
+```shell
+aws rds delete-db-snapshot --db-snapshot-identifier <SNAPSHOT_NAME>
+```
+
+## Other Important Observations
+
+- **Deletion is irreversible.** Unless you have a snapshot to restore from, the data is gone.
+- **Associated resources are not automatically deleted.** Subnet groups, parameter groups, and security groups must be cleaned up separately.
+- **CloudWatch logs and metrics are not deleted with the instance.** These persist and continue to incur costs if not addressed.
+- **Multi-AZ instances** remove both the primary and standby when deleted.
+- **Consider stopping the instance first** to save on compute costs without committing to full deletion. A stopped instance can be restarted within 7 days (after that, it is automatically started by RDS).
+  ```shell
+  aws rds stop-db-instance --db-instance-identifier <INSTANCE_ID>
+  ```
+- **Review manual snapshot storage costs** periodically to avoid unexpected charges from forgotten snapshots.
+- **RDS Custom instances** — deleting an RDS Custom instance permanently deletes the underlying EC2 instance and associated EBS volumes. Do not terminate or delete these resources separately before deleting the RDS instance, as it may cause the deletion and final snapshot creation to fail. Read replicas and RDS Custom instances require `--skip-final-snapshot`.

--- a/databases/rds-deletion.md
+++ b/databases/rds-deletion.md
@@ -87,3 +87,9 @@ aws rds delete-db-instance \
 - **Multi-AZ instances** remove both the primary and standby when deleted.
 - **Review manual snapshot storage costs** periodically to avoid unexpected charges from forgotten snapshots.
 - **RDS Custom instances** — deleting an RDS Custom instance permanently deletes the underlying EC2 instance and associated EBS volumes. Do not terminate or delete these resources separately before deleting the RDS instance, as it may cause the deletion and final snapshot creation to fail. Read replicas and RDS Custom instances require `--skip-final-snapshot`.
+
+## References
+
+- [AWS CLI RDS Reference](https://docs.aws.amazon.com/cli/latest/reference/rds/)
+- [delete-db-instance](https://docs.aws.amazon.com/cli/latest/reference/rds/delete-db-instance.html)
+- [Deleting a DB Instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_DeleteInstance.html)

--- a/databases/rds-deletion.md
+++ b/databases/rds-deletion.md
@@ -85,9 +85,5 @@ aws rds delete-db-instance \
 - **Associated resources are not automatically deleted.** Subnet groups, parameter groups, and security groups must be cleaned up separately.
 - **CloudWatch logs and metrics are not deleted with the instance.** These persist and continue to incur costs if not addressed.
 - **Multi-AZ instances** remove both the primary and standby when deleted.
-- **Consider stopping the instance first** to save on compute costs without committing to full deletion. A stopped instance can be restarted within 7 days (after that, it is automatically started by RDS).
-  ```shell
-  aws rds stop-db-instance --db-instance-identifier <INSTANCE_ID>
-  ```
 - **Review manual snapshot storage costs** periodically to avoid unexpected charges from forgotten snapshots.
 - **RDS Custom instances** — deleting an RDS Custom instance permanently deletes the underlying EC2 instance and associated EBS volumes. Do not terminate or delete these resources separately before deleting the RDS instance, as it may cause the deletion and final snapshot creation to fail. Read replicas and RDS Custom instances require `--skip-final-snapshot`.

--- a/databases/rds-deletion.md
+++ b/databases/rds-deletion.md
@@ -1,54 +1,12 @@
 # RDS Instance Deletion
 
-Deleting an RDS instance is a permanent action. Once deleted, the instance and its automated backups are gone. This document covers the considerations you should take before proceeding with the deletion of an RDS instance.
+Deleting an RDS instance is a permanent action. Once deleted, the instance and its automated backups are gone. This document covers the considerations you should take before proceeding with the deletion of a manually-created RDS instance.
 
 ## Pre-Deletion Checklist
 
-Verify the instance is not in use by checking active connections and application configurations:
-```shell
-aws rds describe-db-instances --db-instance-identifier <INSTANCE_ID> \
-  --query 'DBInstances[0].DBInstanceStatus'
-```
-
-Check if the instance is managed by infrastructure-as-code (CloudFormation, Terraform, CDK). If so, delete it through the IaC tool instead of manually:
-```shell
-# CloudFormation
-aws cloudformation list-stack-resources --stack-name <STACK_NAME>
-
-# Terraform
-terraform state list | grep rds
-```
-
-Check for read replicas. These must be deleted before the primary instance. Note that read replicas require `--skip-final-snapshot` when deleting:
-```shell
-aws rds describe-db-instances --db-instance-identifier <INSTANCE_ID> \
-  --query 'DBInstances[0].ReadReplicaDBInstanceIdentifiers'
-```
-
-Check if deletion protection is enabled and disable it if needed:
-```shell
-# Check
-aws rds describe-db-instances --db-instance-identifier <INSTANCE_ID> \
-  --query 'DBInstances[0].DeletionProtection'
-
-# Disable
-aws rds modify-db-instance --db-instance-identifier <INSTANCE_ID> \
-  --no-deletion-protection --apply-immediately
-```
-
-Confirm the instance was not created from a snapshot (useful to know for rollback purposes):
-```shell
-aws rds describe-db-instances --db-instance-identifier <INSTANCE_ID> \
-  --query 'DBInstances[0].SnapshotIdentifier'
-```
-
-Check if the instance is in a failure state. Instances with status `failed`, `incompatible-restore`, or `incompatible-network` can only be deleted with `--skip-final-snapshot` (no final snapshot will be created):
-```shell
-aws rds describe-db-instances --db-instance-identifier <INSTANCE_ID> \
-  --query 'DBInstances[0].DBInstanceStatus'
-```
-
-Verify there are no dependent resources such as applications, Lambda functions, CloudWatch alarms, or DNS records pointing to the instance endpoint.
+- Check for read replicas — these must be deleted before the primary instance and require `--skip-final-snapshot`
+- Disable deletion protection if enabled
+- Check if the instance is in a failure state (`failed`, `incompatible-restore`, or `incompatible-network`) — can only delete with `--skip-final-snapshot`
 
 ## Snapshots
 
@@ -101,6 +59,24 @@ aws rds wait db-snapshot-available --db-snapshot-identifier <SNAPSHOT_NAME>
 Manual snapshots persist indefinitely and incur storage costs. Set a reminder to delete them when no longer needed:
 ```shell
 aws rds delete-db-snapshot --db-snapshot-identifier <SNAPSHOT_NAME>
+```
+
+## Deletion
+
+With a final snapshot (default):
+```shell
+aws rds delete-db-instance \
+  --db-instance-identifier <INSTANCE_ID> \
+  --final-db-snapshot-identifier <SNAPSHOT_NAME> \
+  --delete-automated-backups
+```
+
+Without a final snapshot (only for failure states or read replicas):
+```shell
+aws rds delete-db-instance \
+  --db-instance-identifier <INSTANCE_ID> \
+  --skip-final-snapshot \
+  --delete-automated-backups
 ```
 
 ## Other Important Observations

--- a/databases/rds-deletion.md
+++ b/databases/rds-deletion.md
@@ -5,8 +5,25 @@ Deleting an RDS instance is a permanent action. Once deleted, the instance and i
 ## Pre-Deletion Checklist
 
 - Check for read replicas — these must be deleted before the primary instance and require `--skip-final-snapshot`
+  ```shell
+  aws rds describe-db-instances --db-instance-identifier <INSTANCE_ID> \
+    --query 'DBInstances[0].ReadReplicaDBInstanceIdentifiers'
+  ```
 - Disable deletion protection if enabled
+  ```shell
+  # Check
+  aws rds describe-db-instances --db-instance-identifier <INSTANCE_ID> \
+    --query 'DBInstances[0].DeletionProtection'
+
+  # Disable
+  aws rds modify-db-instance --db-instance-identifier <INSTANCE_ID> \
+    --no-deletion-protection --apply-immediately
+  ```
 - Check if the instance is in a failure state (`failed`, `incompatible-restore`, or `incompatible-network`) — can only delete with `--skip-final-snapshot`
+  ```shell
+  aws rds describe-db-instances --db-instance-identifier <INSTANCE_ID> \
+    --query 'DBInstances[0].DBInstanceStatus'
+  ```
 
 ## Snapshots
 
@@ -71,7 +88,7 @@ aws rds delete-db-instance \
   --delete-automated-backups
 ```
 
-Without a final snapshot (only for failure states or read replicas):
+Without a final snapshot (only for failure states, read replicas, or RDS Custom):
 ```shell
 aws rds delete-db-instance \
   --db-instance-identifier <INSTANCE_ID> \
@@ -86,7 +103,11 @@ aws rds delete-db-instance \
 - **CloudWatch logs and metrics are not deleted with the instance.** These persist and continue to incur costs if not addressed.
 - **Multi-AZ instances** remove both the primary and standby when deleted.
 - **Review manual snapshot storage costs** periodically to avoid unexpected charges from forgotten snapshots.
-- **RDS Custom instances** — deleting an RDS Custom instance permanently deletes the underlying EC2 instance and associated EBS volumes. Do not terminate or delete these resources separately before deleting the RDS instance, as it may cause the deletion and final snapshot creation to fail. Read replicas and RDS Custom instances require `--skip-final-snapshot`.
+- **RDS Custom instances** — deleting an RDS Custom instance permanently deletes the underlying EC2 instance and associated EBS volumes. Do not terminate or delete those resources yourself before deleting the RDS instance. Read replicas and RDS Custom instances require `--skip-final-snapshot`.
+
+## Related Scripts
+
+- [`scripts/rds-modify-snapshot.sh`](../scripts/rds-modify-snapshot.sh) — batch-modify RDS DB snapshot option groups (`awsbackup` or `manual` snapshots).
 
 ## References
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the first **Databases** section to this AWS knowledge wiki, focused on a practical RDS instance deletion runbook.

## Changes

- Add [`databases/rds-deletion.md`](databases/rds-deletion.md) with pre-deletion checklist (including AWS CLI), snapshot guidance, delete commands, observations, related scripts, and AWS docs references
- Add [`databases/README.md`](databases/README.md) as the section index
- Wire the Databases overview and RDS Deletion guide into the root [`README.md`](README.md)
- Cross-link existing [`scripts/rds-modify-snapshot.sh`](scripts/rds-modify-snapshot.sh)

## Out of scope

- Broader Databases coverage (Aurora, restore-from-snapshot, general `cli/rds.md`)
- Changes to `scripts/rds-modify-snapshot.sh` itself

## Note

This supersedes the unfinished description on #17 (`rds-databases`). Same commits; prefer merging this PR (or copy this body onto #17 and close this one).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b83e2638-1356-4d7f-a3c1-481964cfc150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b83e2638-1356-4d7f-a3c1-481964cfc150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

