### PR TITLE
docs(scripts): add scripts index and link from root README (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A personal wiki of AWS knowledge. CLI commands, practical tips, and lessons lear
   - [CodeBuild](./developer-tools/codebuild/README.md)
   - [CodePipeline](./developer-tools/codepipeline/README.md)
 - [Scripts](#scripts)
+  - [Overview](./scripts/README.md)
   - [ec2-inventory.sh](./scripts/ec2-inventory.sh)
   - [rds-modify-snapshot.sh](./scripts/rds-modify-snapshot.sh)
   - [s3-bucket-object.sh](./scripts/s3-bucket-object.sh)
@@ -129,7 +130,9 @@ See [developer-tools/README.md](./developer-tools/README.md) for more details.
 
 Helper scripts for common operational tasks.
 
+See [scripts/README.md](./scripts/README.md) for the section index (purpose, read-only vs write, related docs).
+
 - [`scripts/ec2-inventory.sh`](./scripts/ec2-inventory.sh) — read-only, instance-scoped inventory (volumes, snapshots, AMIs, DLM, Backup).
-- [`scripts/rds-modify-snapshot.sh`](./scripts/rds-modify-snapshot.sh) — batch-modify RDS DB snapshot option groups.
+- [`scripts/rds-modify-snapshot.sh`](./scripts/rds-modify-snapshot.sh) — batch-modify RDS DB snapshot option groups (**write**).
 - [`scripts/s3-bucket-object.sh`](./scripts/s3-bucket-object.sh) — list object counts per S3 bucket.
 - [`scripts/list-resources.sh`](./scripts/list-resources.sh) — list account resources across profiles/regions.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,26 @@
+# Scripts
+
+Helper scripts for common AWS operational tasks.
+
+Convention: prefer **read-only** helpers for inventory/discovery. Write helpers should support `--dry-run` where practical and make side effects obvious.
+
+## Index
+
+| Script | Mode | Purpose | Related docs |
+|--------|------|---------|--------------|
+| [`ec2-inventory.sh`](./ec2-inventory.sh) | Read-only | Instance-scoped inventory of volumes, snapshots, AMIs, DLM policies, and AWS Backup recovery points (JSON/CSV report) | [EC2 Elimination](../ec2/ec2-elimination.md), [ec2/](../ec2/README.md) |
+| [`list-resources.sh`](./list-resources.sh) | Read-only | List account resources via Resource Groups Tagging API (profiles/regions, optional report) | [AWS List Resources](../aws-list-resources/README.md) |
+| [`s3-bucket-object.sh`](./s3-bucket-object.sh) | Read-only | List S3 buckets and object counts | [cli/s3.md](../cli/s3.md) |
+| [`rds-modify-snapshot.sh`](./rds-modify-snapshot.sh) | **Write** | Batch-modify RDS DB snapshot option groups (supports `--dry-run`) | [RDS Deletion](../databases/rds-deletion.md), [databases/](../databases/README.md) |
+
+## Relationships
+
+- **EC2 inventory vs future snapshot helper:** `ec2-inventory.sh` only reports what exists. Creating final/manual EBS snapshots before a change is a separate write workflow (tracked as a future helper; see issue discussions around EC2 final snapshots).
+- **RDS:** `rds-modify-snapshot.sh` changes snapshot metadata (option groups); it does not delete instances. Pair with the RDS deletion guide when planning teardown.
+- **Discovery:** `list-resources.sh` is account-wide tagging-API discovery; `ec2-inventory.sh` is deep and instance-scoped.
+
+## Usage notes
+
+- Requires AWS CLI (and `jq` where noted by each script).
+- Pass `--profile` / `--region` (or configure defaults) as documented in each script’s `--help`.
+- Always prefer `--dry-run` on write scripts before applying changes.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a dedicated scripts index and wires it into the root wiki README.

- New [`scripts/README.md`](scripts/README.md): purpose, read-only vs write, related docs for each helper
- Notes relationships (EC2 inventory vs future snapshot helper, RDS write helper, account-wide discovery)
- Root README Scripts section links to the new overview

Closes #23

## Test plan

- [x] `scripts/README.md` lists all four current helpers
- [x] Root README TOC + Scripts section link to `./scripts/README.md`
- [x] Relative links resolve locally
- [x] Skim rendered pages on GitHub
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f188cde4-bc70-477c-ab5a-d2e0dc365992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f188cde4-bc70-477c-ab5a-d2e0dc365992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

