### PR TITLE
feat(ec2): manual/final snapshots + AMI mode (#21, #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Helper scripts for common operational tasks.
 See [scripts/README.md](./scripts/README.md) for the section index (purpose, read-only vs write, related docs).
 
 - [`scripts/ec2-inventory.sh`](./scripts/ec2-inventory.sh) — read-only, instance-scoped inventory (volumes, snapshots, AMIs, DLM, Backup).
-- [`scripts/ec2-final-snapshot.sh`](./scripts/ec2-final-snapshot.sh) — create crash-consistent manual/final EBS snapshots (**write**).
+- [`scripts/ec2-final-snapshot.sh`](./scripts/ec2-final-snapshot.sh) — create manual/final EBS snapshots or AMIs (**write**; `--mode volumes|ami`).
 - [`scripts/rds-modify-snapshot.sh`](./scripts/rds-modify-snapshot.sh) — batch-modify RDS DB snapshot option groups (**write**).
 - [`scripts/s3-bucket-object.sh`](./scripts/s3-bucket-object.sh) — list object counts per S3 bucket.
 - [`scripts/list-resources.sh`](./scripts/list-resources.sh) — list account resources across profiles/regions.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A personal wiki of AWS knowledge. CLI commands, practical tips, and lessons lear
   - [RDS Deletion](./databases/rds-deletion.md)
 - [EC2](#ec2)
   - [Overview](./ec2/README.md)
+  - [Manual / final snapshots](./ec2/manual-snapshots.md)
   - [EC2 Elimination](./ec2/ec2-elimination.md)
 - [AWS List Resources](#aws-list-resources)
   - [Overview](./aws-list-resources/README.md)
@@ -53,6 +54,7 @@ A personal wiki of AWS knowledge. CLI commands, practical tips, and lessons lear
 - [Scripts](#scripts)
   - [Overview](./scripts/README.md)
   - [ec2-inventory.sh](./scripts/ec2-inventory.sh)
+  - [ec2-final-snapshot.sh](./scripts/ec2-final-snapshot.sh)
   - [rds-modify-snapshot.sh](./scripts/rds-modify-snapshot.sh)
   - [s3-bucket-object.sh](./scripts/s3-bucket-object.sh)
   - [list-resources.sh](./scripts/list-resources.sh)
@@ -101,6 +103,7 @@ Operational guides and good practices for day-to-day Amazon EC2 work — invento
 
 See [ec2/README.md](./ec2/README.md) for the section index.
 
+- [Manual / final snapshots](./ec2/manual-snapshots.md) — intentional EBS snapshots before risky or destructive changes.
 - [EC2 Elimination](./ec2/ec2-elimination.md) — inventory volumes, snapshots, AMIs, DLM, and AWS Backup before removing EC2 resources.
 
 ---
@@ -133,6 +136,7 @@ Helper scripts for common operational tasks.
 See [scripts/README.md](./scripts/README.md) for the section index (purpose, read-only vs write, related docs).
 
 - [`scripts/ec2-inventory.sh`](./scripts/ec2-inventory.sh) — read-only, instance-scoped inventory (volumes, snapshots, AMIs, DLM, Backup).
+- [`scripts/ec2-final-snapshot.sh`](./scripts/ec2-final-snapshot.sh) — create crash-consistent manual/final EBS snapshots (**write**).
 - [`scripts/rds-modify-snapshot.sh`](./scripts/rds-modify-snapshot.sh) — batch-modify RDS DB snapshot option groups (**write**).
 - [`scripts/s3-bucket-object.sh`](./scripts/s3-bucket-object.sh) — list object counts per S3 bucket.
 - [`scripts/list-resources.sh`](./scripts/list-resources.sh) — list account resources across profiles/regions.

--- a/ec2/README.md
+++ b/ec2/README.md
@@ -1,9 +1,10 @@
 # EC2
 
-Operational guides for Amazon EC2 elimination, backups, and related cleanup.
+Operational guides and good practices for day-to-day Amazon EC2 work — inventory, backups, snapshots, and cleanup.
 
 ## Guides
 
+- [Manual / final snapshots](./manual-snapshots.md) — when and how to take intentional EBS snapshots before risky changes
 - [EC2 Elimination](./ec2-elimination.md) — inventory, snapshots, AMIs, backups, and checklist for removing EC2 resources safely
   - Includes [Investigate recovery points](./ec2-elimination.md#investigate-recovery-points-before-adding-a-backup-filter) before adding any Backup filter
 
@@ -17,4 +18,5 @@ Operational guides for Amazon EC2 elimination, backups, and related cleanup.
 
 ## Related Scripts
 
-- [`scripts/ec2-inventory.sh`](../scripts/ec2-inventory.sh) — read-only, instance-scoped JSON/CSV report generator for volumes, snapshots, AMIs, DLM, and AWS Backup
+- [`scripts/ec2-inventory.sh`](../scripts/ec2-inventory.sh) — read-only, instance-scoped JSON/CSV report (volumes, snapshots, AMIs, DLM, AWS Backup)
+- [`scripts/ec2-final-snapshot.sh`](../scripts/ec2-final-snapshot.sh) — create crash-consistent final/manual snapshots for live instances (**write**)

--- a/ec2/README.md
+++ b/ec2/README.md
@@ -19,4 +19,4 @@ Operational guides and good practices for day-to-day Amazon EC2 work — invento
 ## Related Scripts
 
 - [`scripts/ec2-inventory.sh`](../scripts/ec2-inventory.sh) — read-only, instance-scoped JSON/CSV report (volumes, snapshots, AMIs, DLM, AWS Backup)
-- [`scripts/ec2-final-snapshot.sh`](../scripts/ec2-final-snapshot.sh) — create crash-consistent final/manual snapshots for live instances (**write**)
+- [`scripts/ec2-final-snapshot.sh`](../scripts/ec2-final-snapshot.sh) — create final/manual volume snapshots or AMIs for live instances (**write**; `--mode volumes|ami`)

--- a/ec2/ec2-elimination.md
+++ b/ec2/ec2-elimination.md
@@ -252,8 +252,8 @@ For elimination projects, inventory **all four**. Keeping only “EC2 console sn
 
 Decide retention before terminate:
 
-1. **Need relaunchable image?** Create an AMI (optionally without reboot).
-2. **Need volume-level restore only?** Snapshot specific volumes (prefer the [manual / final snapshots](./manual-snapshots.md) practice and [`scripts/ec2-final-snapshot.sh`](../scripts/ec2-final-snapshot.sh)).
+1. **Need relaunchable image?** Create an AMI via [`ec2-final-snapshot.sh --mode ami`](../scripts/ec2-final-snapshot.sh) (running instances reboot by default) or the CLI below.
+2. **Need volume-level restore only?** Use `--mode volumes` (default) on the same helper — see [manual / final snapshots](./manual-snapshots.md).
 3. **Already covered by AWS Backup / DLM?** Confirm recent successful recovery points before deleting compute.
 
 ### Create a final AMI

--- a/ec2/ec2-elimination.md
+++ b/ec2/ec2-elimination.md
@@ -253,7 +253,7 @@ For elimination projects, inventory **all four**. Keeping only “EC2 console sn
 Decide retention before terminate:
 
 1. **Need relaunchable image?** Create an AMI (optionally without reboot).
-2. **Need volume-level restore only?** Snapshot specific volumes.
+2. **Need volume-level restore only?** Snapshot specific volumes (prefer the [manual / final snapshots](./manual-snapshots.md) practice and [`scripts/ec2-final-snapshot.sh`](../scripts/ec2-final-snapshot.sh)).
 3. **Already covered by AWS Backup / DLM?** Confirm recent successful recovery points before deleting compute.
 
 ### Create a final AMI
@@ -289,7 +289,7 @@ aws ec2 wait snapshot-completed --snapshot-ids <SNAPSHOT_ID>
 
 - [ ] Inventory instances, volumes, snapshots, AMIs, DLM, AWS Backup
 - [ ] Confirm which volumes have `DeleteOnTermination=true` vs `false`
-- [ ] Create final AMI and/or snapshots if retention is required
+- [ ] Create final AMI and/or snapshots if retention is required ([manual snapshots](./manual-snapshots.md) / [`ec2-final-snapshot.sh`](../scripts/ec2-final-snapshot.sh))
 - [ ] Note Elastic IPs, ENIs, and security groups in use
 - [ ] Check Auto Scaling groups / launch templates / load balancers that reference the instances
 - [ ] Stop applications / drain traffic if needed

--- a/ec2/ec2-elimination.md
+++ b/ec2/ec2-elimination.md
@@ -261,7 +261,7 @@ Decide retention before terminate:
 ```shell
 aws ec2 create-image \
   --instance-id <INSTANCE_ID> \
-  --name "final-<INSTANCE_ID>-$(date +%Y%m%d)" \
+  --name "<Name-or-instance-id>-<INSTANCE_ID>-$(date -u +%Y%m%d-%H%M%S)-final" \
   --description "Final AMI before EC2 elimination" \
   --no-reboot
 ```

--- a/ec2/manual-snapshots.md
+++ b/ec2/manual-snapshots.md
@@ -1,6 +1,6 @@
 # Manual / final EC2 snapshots
 
-Intentional EBS snapshots before a destructive or hard-to-reverse EC2 change — decommission, volume replace, migration, or a risky config change. This is a day-to-day ops practice; elimination is one consumer of it.
+Intentional backups before a destructive or hard-to-reverse EC2 change — decommission, volume replace, migration, or a risky config change. This is a day-to-day ops practice; elimination is one consumer of it.
 
 For a full teardown checklist, see [EC2 Elimination](./ec2-elimination.md).
 
@@ -11,39 +11,46 @@ For a full teardown checklist, see [EC2 Elimination](./ec2-elimination.md).
 - Before a major OS or application change where rollback matters
 - When AWS Backup / DLM coverage is unclear or not recent enough
 
-Prefer stopping the instance first when downtime is acceptable (cleaner consistency). Snapshots of a **running** instance are still valid but crash-consistent (like power loss).
-
 ## Snapshot vs AMI
 
-| Need | Use |
-|------|-----|
-| Restore disks / keep data | **EBS snapshot** (this practice) |
-| Relaunch the same instance shape later | **AMI** (`create-image`) — see [Final backup procedure](./ec2-elimination.md#final-backup-procedure) |
+| Need | Use | Helper mode |
+|------|-----|-------------|
+| Restore disks / keep data | **EBS snapshots** | `--mode volumes` (default) |
+| Relaunch the same instance shape later | **AMI** (`create-image`) | `--mode ami` |
+
+## Consistency
+
+- **Volumes mode:** crash-consistent multi-volume set (`create-snapshots`). Prefer stopping first when downtime is OK.
+- **AMI mode (default):** for a **running** instance, AWS **reboots** during `create-image` so buffered data is flushed (safer). A stopped instance stays stopped.
+- **AMI `--no-reboot`:** crash-consistent AMI; filesystem integrity is not guaranteed — use only when reboot is unacceptable.
 
 ## Tagging model
 
-The helper uses `aws ec2 create-snapshots` with:
+| Mode | Copied from volumes? | Script default | Optional |
+|------|----------------------|----------------|----------|
+| `volumes` | Yes (`--copy-tags-from-source volume`) | `Purpose=manual-final-snapshot` | `--tag Key=Value` |
+| `ami` | No (AMI API limitation) | Same `Purpose` on AMI **and** all backing snapshots | `--tag Key=Value` on AMI + all backing snapshots |
 
-| Source | What |
-|--------|------|
-| Volume | All existing volume tags (`--copy-tags-from-source volume`) |
-| Script default | `Purpose=manual-final-snapshot` only |
-| Optional | Repeatable `--tag Key=Value` (ticket, reason, …) |
+**Not** set by the script as a tag: `Name` or `CreatedBy=<script-name>`.
 
-**Not** set by the script: `Name` (would overwrite copied volume names across the set) or `CreatedBy=<script-name>`.
+In AMI mode the script generates the required `create-image --name` value internally (e.g. `final-<instance-id>-<timestamp>`). That is the AMI Name field, not a `Name` tag, and there is no user `--name` flag.
 
-Instance correlation belongs in the snapshot **description** and the JSON report.
+Instance correlation belongs in the description and the JSON report.
 
 ## Retention
 
-Manual snapshots persist and incur storage cost until you delete them. Set a reminder to remove them after restore confidence is high.
+Manual snapshots and AMIs persist and incur storage cost until you delete them. Deregistering an AMI does **not** delete its backing snapshots. Set a reminder to clean up after restore confidence is high.
 
 ## Helper script
 
 ```shell
+# Volume snapshots (default)
 ./scripts/ec2-final-snapshot.sh -i <INSTANCE_ID> --region <REGION> --dry-run
-./scripts/ec2-final-snapshot.sh -i <INSTANCE_ID> --profile <PROFILE> --tag ChangeTicket=CHG123
-./scripts/ec2-final-snapshot.sh -i i-aaa -i i-bbb --wait --yes
+./scripts/ec2-final-snapshot.sh -i <INSTANCE_ID> --tag ChangeTicket=CHG123
+
+# AMI (reboots running instances by default)
+./scripts/ec2-final-snapshot.sh -i <INSTANCE_ID> --mode ami --wait --yes
+./scripts/ec2-final-snapshot.sh -i <INSTANCE_ID> --mode ami --no-reboot --dry-run
 ```
 
 Requires a **live** instance (attached volumes). Does not terminate or delete anything. See [`scripts/ec2-final-snapshot.sh`](../scripts/ec2-final-snapshot.sh) and [`scripts/README.md`](../scripts/README.md).
@@ -54,9 +61,9 @@ Pair with read-only inventory first:
 ./scripts/ec2-inventory.sh -i <INSTANCE_ID> --region <REGION>
 ```
 
-## Manual CLI (single volume)
+## Manual CLI
 
-If you only need one volume:
+Single volume:
 
 ```shell
 aws ec2 create-snapshot \
@@ -65,4 +72,16 @@ aws ec2 create-snapshot \
   --tag-specifications 'ResourceType=snapshot,Tags=[{Key=Purpose,Value=manual-final-snapshot}]'
 ```
 
-For multi-volume crash-consistent sets with tag copy, prefer the helper (or `aws ec2 create-snapshots` directly). More CLI notes: [`cli/ec2-snapshots.md`](../cli/ec2-snapshots.md).
+AMI (AWS reboots a running instance unless `--no-reboot`):
+
+```shell
+aws ec2 create-image \
+  --instance-id <INSTANCE_ID> \
+  --name "final-<INSTANCE_ID>-$(date -u +%Y%m%dT%H%M%SZ)" \
+  --description "Manual final AMI for <INSTANCE_ID>" \
+  --tag-specifications \
+    'ResourceType=image,Tags=[{Key=Purpose,Value=manual-final-snapshot}]' \
+    'ResourceType=snapshot,Tags=[{Key=Purpose,Value=manual-final-snapshot}]'
+```
+
+Prefer the helper for multi-volume sets, tag copy (volumes mode), and consistent reporting. More CLI notes: [`cli/ec2-snapshots.md`](../cli/ec2-snapshots.md), [`cli/ec2-ami.md`](../cli/ec2-ami.md).

--- a/ec2/manual-snapshots.md
+++ b/ec2/manual-snapshots.md
@@ -33,7 +33,7 @@ For a full teardown checklist, see [EC2 Elimination](./ec2-elimination.md).
 
 **Not** set by the script as a tag: `Name` or `CreatedBy=<script-name>`.
 
-In AMI mode the script generates the required `create-image --name` value internally (e.g. `final-<instance-id>-<timestamp>`). That is the AMI Name field, not a `Name` tag, and there is no user `--name` flag.
+In AMI mode the script generates the required `create-image --name` value internally from the instance `Name` tag (when present), the instance ID, a UTC `YYYYMMDD-HHMMSS` stamp, and a `-final` suffix — e.g. `web-prod-i-0abc123-20260710-204500-final`. That is the AMI Name field, not a `Name` tag, and there is no user `--name` flag.
 
 Instance correlation belongs in the description and the JSON report.
 
@@ -77,7 +77,7 @@ AMI (AWS reboots a running instance unless `--no-reboot`):
 ```shell
 aws ec2 create-image \
   --instance-id <INSTANCE_ID> \
-  --name "final-<INSTANCE_ID>-$(date -u +%Y%m%dT%H%M%SZ)" \
+  --name "<Name-or-instance-id>-<INSTANCE_ID>-$(date -u +%Y%m%d-%H%M%S)-final" \
   --description "Manual final AMI for <INSTANCE_ID>" \
   --tag-specifications \
     'ResourceType=image,Tags=[{Key=Purpose,Value=manual-final-snapshot}]' \

--- a/ec2/manual-snapshots.md
+++ b/ec2/manual-snapshots.md
@@ -1,0 +1,68 @@
+# Manual / final EC2 snapshots
+
+Intentional EBS snapshots before a destructive or hard-to-reverse EC2 change — decommission, volume replace, migration, or a risky config change. This is a day-to-day ops practice; elimination is one consumer of it.
+
+For a full teardown checklist, see [EC2 Elimination](./ec2-elimination.md).
+
+## When to take them
+
+- Before terminating or replacing an instance
+- Before detaching / replacing a data volume
+- Before a major OS or application change where rollback matters
+- When AWS Backup / DLM coverage is unclear or not recent enough
+
+Prefer stopping the instance first when downtime is acceptable (cleaner consistency). Snapshots of a **running** instance are still valid but crash-consistent (like power loss).
+
+## Snapshot vs AMI
+
+| Need | Use |
+|------|-----|
+| Restore disks / keep data | **EBS snapshot** (this practice) |
+| Relaunch the same instance shape later | **AMI** (`create-image`) — see [Final backup procedure](./ec2-elimination.md#final-backup-procedure) |
+
+## Tagging model
+
+The helper uses `aws ec2 create-snapshots` with:
+
+| Source | What |
+|--------|------|
+| Volume | All existing volume tags (`--copy-tags-from-source volume`) |
+| Script default | `Purpose=manual-final-snapshot` only |
+| Optional | Repeatable `--tag Key=Value` (ticket, reason, …) |
+
+**Not** set by the script: `Name` (would overwrite copied volume names across the set) or `CreatedBy=<script-name>`.
+
+Instance correlation belongs in the snapshot **description** and the JSON report.
+
+## Retention
+
+Manual snapshots persist and incur storage cost until you delete them. Set a reminder to remove them after restore confidence is high.
+
+## Helper script
+
+```shell
+./scripts/ec2-final-snapshot.sh -i <INSTANCE_ID> --region <REGION> --dry-run
+./scripts/ec2-final-snapshot.sh -i <INSTANCE_ID> --profile <PROFILE> --tag ChangeTicket=CHG123
+./scripts/ec2-final-snapshot.sh -i i-aaa -i i-bbb --wait --yes
+```
+
+Requires a **live** instance (attached volumes). Does not terminate or delete anything. See [`scripts/ec2-final-snapshot.sh`](../scripts/ec2-final-snapshot.sh) and [`scripts/README.md`](../scripts/README.md).
+
+Pair with read-only inventory first:
+
+```shell
+./scripts/ec2-inventory.sh -i <INSTANCE_ID> --region <REGION>
+```
+
+## Manual CLI (single volume)
+
+If you only need one volume:
+
+```shell
+aws ec2 create-snapshot \
+  --volume-id <VOLUME_ID> \
+  --description "Manual final snapshot for <INSTANCE_ID>" \
+  --tag-specifications 'ResourceType=snapshot,Tags=[{Key=Purpose,Value=manual-final-snapshot}]'
+```
+
+For multi-volume crash-consistent sets with tag copy, prefer the helper (or `aws ec2 create-snapshots` directly). More CLI notes: [`cli/ec2-snapshots.md`](../cli/ec2-snapshots.md).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,14 +8,15 @@ Convention: prefer **read-only** helpers for inventory/discovery. Write helpers 
 
 | Script | Mode | Purpose | Related docs |
 |--------|------|---------|--------------|
-| [`ec2-inventory.sh`](./ec2-inventory.sh) | Read-only | Instance-scoped inventory of volumes, snapshots, AMIs, DLM policies, and AWS Backup recovery points (JSON/CSV report) | [EC2 Elimination](../ec2/ec2-elimination.md), [ec2/](../ec2/README.md) |
+| [`ec2-inventory.sh`](./ec2-inventory.sh) | Read-only | Instance-scoped inventory of volumes, snapshots, AMIs, DLM policies, and AWS Backup recovery points (JSON/CSV report) | [EC2 Elimination](../ec2/ec2-elimination.md), [Manual snapshots](../ec2/manual-snapshots.md), [ec2/](../ec2/README.md) |
+| [`ec2-final-snapshot.sh`](./ec2-final-snapshot.sh) | **Write** | Crash-consistent EBS snapshots for live instances (`create-snapshots`, copy volume tags, `Purpose=manual-final-snapshot`; supports `--dry-run`) | [Manual snapshots](../ec2/manual-snapshots.md), [EC2 Elimination](../ec2/ec2-elimination.md) |
 | [`list-resources.sh`](./list-resources.sh) | Read-only | List account resources via Resource Groups Tagging API (profiles/regions, optional report) | [AWS List Resources](../aws-list-resources/README.md) |
 | [`s3-bucket-object.sh`](./s3-bucket-object.sh) | Read-only | List S3 buckets and object counts | [cli/s3.md](../cli/s3.md) |
 | [`rds-modify-snapshot.sh`](./rds-modify-snapshot.sh) | **Write** | Batch-modify RDS DB snapshot option groups (supports `--dry-run`) | [RDS Deletion](../databases/rds-deletion.md), [databases/](../databases/README.md) |
 
 ## Relationships
 
-- **EC2 inventory vs future snapshot helper:** `ec2-inventory.sh` only reports what exists. Creating final/manual EBS snapshots before a change is a separate write workflow (tracked as a future helper; see issue discussions around EC2 final snapshots).
+- **EC2 inventory vs final snapshots:** `ec2-inventory.sh` only reports what exists. `ec2-final-snapshot.sh` creates intentional snapshots before a change (does not terminate or delete).
 - **RDS:** `rds-modify-snapshot.sh` changes snapshot metadata (option groups); it does not delete instances. Pair with the RDS deletion guide when planning teardown.
 - **Discovery:** `list-resources.sh` is account-wide tagging-API discovery; `ec2-inventory.sh` is deep and instance-scoped.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,14 +9,14 @@ Convention: prefer **read-only** helpers for inventory/discovery. Write helpers 
 | Script | Mode | Purpose | Related docs |
 |--------|------|---------|--------------|
 | [`ec2-inventory.sh`](./ec2-inventory.sh) | Read-only | Instance-scoped inventory of volumes, snapshots, AMIs, DLM policies, and AWS Backup recovery points (JSON/CSV report) | [EC2 Elimination](../ec2/ec2-elimination.md), [Manual snapshots](../ec2/manual-snapshots.md), [ec2/](../ec2/README.md) |
-| [`ec2-final-snapshot.sh`](./ec2-final-snapshot.sh) | **Write** | Crash-consistent EBS snapshots for live instances (`create-snapshots`, copy volume tags, `Purpose=manual-final-snapshot`; supports `--dry-run`) | [Manual snapshots](../ec2/manual-snapshots.md), [EC2 Elimination](../ec2/ec2-elimination.md) |
+| [`ec2-final-snapshot.sh`](./ec2-final-snapshot.sh) | **Write** | Final backups for live instances: `--mode volumes` (`create-snapshots`, copy volume tags) or `--mode ami` (`create-image`, reboot by default for running instances); `Purpose=manual-final-snapshot`; supports `--dry-run` | [Manual snapshots](../ec2/manual-snapshots.md), [EC2 Elimination](../ec2/ec2-elimination.md) |
 | [`list-resources.sh`](./list-resources.sh) | Read-only | List account resources via Resource Groups Tagging API (profiles/regions, optional report) | [AWS List Resources](../aws-list-resources/README.md) |
 | [`s3-bucket-object.sh`](./s3-bucket-object.sh) | Read-only | List S3 buckets and object counts | [cli/s3.md](../cli/s3.md) |
 | [`rds-modify-snapshot.sh`](./rds-modify-snapshot.sh) | **Write** | Batch-modify RDS DB snapshot option groups (supports `--dry-run`) | [RDS Deletion](../databases/rds-deletion.md), [databases/](../databases/README.md) |
 
 ## Relationships
 
-- **EC2 inventory vs final snapshots:** `ec2-inventory.sh` only reports what exists. `ec2-final-snapshot.sh` creates intentional snapshots before a change (does not terminate or delete).
+- **EC2 inventory vs final snapshots:** `ec2-inventory.sh` only reports what exists. `ec2-final-snapshot.sh` creates intentional volume snapshots and/or AMIs before a change (does not terminate or delete).
 - **RDS:** `rds-modify-snapshot.sh` changes snapshot metadata (option groups); it does not delete instances. Pair with the RDS deletion guide when planning teardown.
 - **Discovery:** `list-resources.sh` is account-wide tagging-API discovery; `ec2-inventory.sh` is deep and instance-scoped.
 

--- a/scripts/ec2-final-snapshot.sh
+++ b/scripts/ec2-final-snapshot.sh
@@ -1,0 +1,568 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Platform note: Git Bash / MSYS may emit CRLF from external commands.
+strip_cr() {
+    printf '%s' "$1" | tr -d '\r'
+}
+
+sanitize_stream() {
+    tr -d '\r'
+}
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+timestamp() {
+    date '+%H:%M:%S'
+}
+
+info() {
+    echo -e "${BLUE}[$(timestamp)] [INFO]${NC} $1" >&2
+}
+
+success() {
+    echo -e "${GREEN}[$(timestamp)] [SUCCESS]${NC} $1" >&2
+}
+
+warning() {
+    echo -e "${YELLOW}[$(timestamp)] [WARNING]${NC} $1" >&2
+}
+
+error() {
+    echo -e "${RED}[$(timestamp)] [ERROR]${NC} $1" >&2
+}
+
+DEFAULT_PURPOSE="manual-final-snapshot"
+
+PROFILE=""
+REGION=""
+DRY_RUN=false
+WAIT_SNAPSHOTS=false
+SKIP_CONFIRM=false
+REPORT_DIR=""
+ACCOUNT_ID=""
+EFFECTIVE_REGION=""
+PROFILE_ARG=""
+REGION_ARG=""
+REPORT_PATH=""
+INSTANCE_IDS=()
+# Parallel arrays for user tags (bash 3–compatible)
+TAG_KEYS=()
+TAG_VALUES=()
+RESULT_FILES=()
+
+usage() {
+    cat << EOF
+Usage: $0 --instance <instance-id>[,<instance-id>...] [OPTIONS]
+
+Create crash-consistent EBS snapshots for attached volumes on live EC2 instances
+(aws ec2 create-snapshots). Copies volume tags and adds Purpose=${DEFAULT_PURPOSE}.
+
+Does NOT terminate or delete resources. Instance must exist.
+
+Required arguments:
+  --instance, -i     One or more instance IDs (repeatable or comma-separated)
+
+Optional arguments:
+  --region, -r       AWS region
+  --profile, -p      AWS profile name
+  --tag Key=Value    Extra snapshot tag (repeatable; cannot override Purpose)
+  --dry-run          Preview volumes/tags; do not create snapshots
+  --wait             Wait until each snapshot completes
+  --yes, -y          Skip confirmation prompt
+  --report-dir       Report directory (default: report/ec2-final-snapshot-<timestamp>)
+  --help, -h         Show this help message
+
+Examples:
+  $0 -i i-0123456789abcdef0 --region us-east-1 --dry-run
+  $0 -i i-aaa --profile prod --tag ChangeTicket=CHG123
+  $0 -i i-aaa -i i-bbb --wait --yes
+
+EOF
+}
+
+check_dependencies() {
+    if ! command -v aws &> /dev/null; then
+        error "aws-cli is not installed or not in PATH."
+        exit 1
+    fi
+    if ! command -v jq &> /dev/null; then
+        error "jq is not installed or not in PATH."
+        exit 1
+    fi
+}
+
+aws_cmd() {
+    # shellcheck disable=SC2086
+    aws "$@" ${PROFILE_ARG} ${REGION_ARG} --no-cli-pager
+}
+
+aws_json() {
+    local output
+    if ! output=$(aws_cmd "$@" --output json 2>&1); then
+        error "AWS command failed: aws $*"
+        error "$output"
+        return 1
+    fi
+    printf '%s' "$output" | sanitize_stream
+}
+
+aws_json_quiet() {
+    local output
+    if ! output=$(aws_cmd "$@" --output json 2>/dev/null); then
+        return 1
+    fi
+    printf '%s' "$output" | sanitize_stream
+}
+
+check_aws_auth() {
+    local region identity
+    if ! identity=$(aws_json sts get-caller-identity); then
+        error "Invalid or missing AWS credentials/access keys."
+        if [[ -n "$PROFILE" ]]; then
+            error "Try: aws sso login --profile $PROFILE"
+        else
+            error "Set AWS credentials or run: aws sso login"
+        fi
+        exit 1
+    fi
+
+    ACCOUNT_ID="$(printf '%s' "$identity" | jq -r '.Account' | tr -d '\r')"
+
+    if [[ -n "$REGION" ]]; then
+        region="$REGION"
+    else
+        region=$(aws configure get region ${PROFILE:+--profile "$PROFILE"} 2>/dev/null | tr -d '\r' || true)
+        [[ -z "$region" ]] && region="not set"
+    fi
+    EFFECTIVE_REGION="$region"
+
+    info "AWS Account: $ACCOUNT_ID"
+    info "AWS Region:  $EFFECTIVE_REGION"
+    if [[ -n "$PROFILE" ]]; then
+        info "AWS Profile: $PROFILE"
+    fi
+}
+
+add_instance_ids() {
+    local raw="$1"
+    local part cleaned
+    raw="$(strip_cr "$raw")"
+    IFS=',' read -ra parts <<< "$raw"
+    for part in "${parts[@]}"; do
+        cleaned="$(strip_cr "$part")"
+        cleaned="${cleaned//[[:space:]]/}"
+        [[ -z "$cleaned" ]] && continue
+        INSTANCE_IDS+=("$cleaned")
+    done
+}
+
+tag_key_exists() {
+    local needle="$1"
+    local k
+    for k in "${TAG_KEYS[@]+"${TAG_KEYS[@]}"}"; do
+        if [[ "$k" == "$needle" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+add_tag() {
+    local raw="$1"
+    local key value
+    raw="$(strip_cr "$raw")"
+    if [[ "$raw" != *=* ]]; then
+        error "Invalid --tag value '$raw' (expected Key=Value)"
+        exit 1
+    fi
+    key="${raw%%=*}"
+    value="${raw#*=}"
+    key="${key#"${key%%[![:space:]]*}"}"
+    key="${key%"${key##*[![:space:]]}"}"
+    if [[ -z "$key" || -z "$value" ]]; then
+        error "Invalid --tag value '$raw' (Key and Value must be non-empty)"
+        exit 1
+    fi
+    if [[ "$key" == "Purpose" ]]; then
+        error "Cannot override Purpose via --tag (fixed to ${DEFAULT_PURPOSE})"
+        exit 1
+    fi
+    if tag_key_exists "$key"; then
+        error "Duplicate --tag key: $key"
+        exit 1
+    fi
+    TAG_KEYS+=("$key")
+    TAG_VALUES+=("$value")
+}
+
+dedupe_instances() {
+    local -a unique=()
+    local id seen
+    for id in "${INSTANCE_IDS[@]}"; do
+        seen=false
+        for existing in "${unique[@]+"${unique[@]}"}"; do
+            if [[ "$existing" == "$id" ]]; then
+                seen=true
+                break
+            fi
+        done
+        [[ "$seen" == false ]] && unique+=("$id")
+    done
+    INSTANCE_IDS=("${unique[@]}")
+}
+
+build_tag_specifications() {
+    local tags_json i
+    tags_json="$(jq -n --arg purpose "$DEFAULT_PURPOSE" '[{Key:"Purpose",Value:$purpose}]')"
+    if [[ ${#TAG_KEYS[@]} -gt 0 ]]; then
+        for i in "${!TAG_KEYS[@]}"; do
+            tags_json="$(jq -c --arg k "${TAG_KEYS[$i]}" --arg v "${TAG_VALUES[$i]}" \
+                '. + [{Key:$k,Value:$v}]' <<< "$tags_json")"
+        done
+    fi
+    jq -nc --argjson tags "$tags_json" \
+        '[{ResourceType:"snapshot",Tags:$tags}]'
+}
+
+format_tags_preview() {
+    local line="Purpose=${DEFAULT_PURPOSE}"
+    local i
+    if [[ ${#TAG_KEYS[@]} -gt 0 ]]; then
+        for i in "${!TAG_KEYS[@]}"; do
+            line+=", ${TAG_KEYS[$i]}=${TAG_VALUES[$i]}"
+        done
+    fi
+    printf '%s' "$line"
+}
+
+confirm_action() {
+    local prompt="$1"
+    local reply
+    if [[ "$SKIP_CONFIRM" = true ]]; then
+        return 0
+    fi
+    warning "$prompt"
+    read -r -p "Continue? [y/N] " reply
+    reply="$(strip_cr "$reply")"
+    case "$reply" in
+        y|Y|yes|YES) return 0 ;;
+        *)
+            info "Skipped"
+            return 1
+            ;;
+    esac
+}
+
+fetch_instance_and_volumes() {
+    local instance_id="$1"
+    local raw
+    if ! raw=$(aws_json_quiet ec2 describe-instances --instance-ids "$instance_id"); then
+        return 1
+    fi
+    printf '%s' "$raw" | jq -c --arg iid "$instance_id" '
+      (.Reservations[0].Instances[0] // null) as $inst
+      | if $inst == null then
+          empty
+        else
+          {
+            instanceId: $iid,
+            state: ($inst.State.Name // "unknown"),
+            instanceType: ($inst.InstanceType // null),
+            volumes: (
+              [$inst.BlockDeviceMappings[]?
+                | select(.Ebs.VolumeId != null)
+                | {
+                    volumeId: .Ebs.VolumeId,
+                    device: (.DeviceName // null),
+                    deleteOnTermination: (.Ebs.DeleteOnTermination // null)
+                  }
+              ] | unique_by(.volumeId)
+            )
+          }
+        end
+    '
+}
+
+process_instance() {
+    local instance_id="$1"
+    local result_file="$2"
+    local preview desc tag_spec created wait_ids snap_json utc status message
+    local -a snapshot_ids=()
+
+    utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    desc="Manual final snapshot for ${instance_id} at ${utc}"
+
+    info "Processing $instance_id"
+    if ! preview=$(fetch_instance_and_volumes "$instance_id"); then
+        error "Instance not found or describe-instances failed: $instance_id"
+        jq -n --arg iid "$instance_id" --arg msg "Instance not found or describe-instances failed" \
+            '{instanceId:$iid,status:"failed",message:$msg,volumes:[],snapshots:[]}' > "$result_file"
+        return 1
+    fi
+    if [[ -z "$preview" || "$preview" == "null" ]]; then
+        error "Instance not returned by describe-instances: $instance_id"
+        jq -n --arg iid "$instance_id" --arg msg "Instance not returned by describe-instances" \
+            '{instanceId:$iid,status:"failed",message:$msg,volumes:[],snapshots:[]}' > "$result_file"
+        return 1
+    fi
+
+    local state vol_count
+    state="$(printf '%s' "$preview" | jq -r '.state')"
+    vol_count="$(printf '%s' "$preview" | jq '.volumes | length')"
+
+    info "  State: $state"
+    info "  Attached volumes: $vol_count"
+    printf '%s' "$preview" | jq -r '.volumes[] | "    - \(.volumeId) device=\(.device // "-") deleteOnTermination=\(.deleteOnTermination|tostring)"' >&2
+    info "  Copy volume tags: yes"
+    info "  Tags to add: $(format_tags_preview)"
+    info "  Description: $desc"
+
+    if [[ "$vol_count" -eq 0 ]]; then
+        warning "  No attached EBS volumes; nothing to snapshot"
+        jq -n --argjson preview "$preview" --arg msg "No attached EBS volumes" \
+            '$preview + {status:"failed",message:$msg,snapshots:[]}' > "$result_file"
+        return 1
+    fi
+
+    if [[ "$DRY_RUN" = true ]]; then
+        success "  Dry-run: would create snapshots (no changes made)"
+        jq -n --argjson preview "$preview" --arg desc "$desc" --arg tags "$(format_tags_preview)" \
+            '$preview + {
+              status:"dry-run",
+              message:"Preview only; create-snapshots not called",
+              description:$desc,
+              tagsToAdd:$tags,
+              copyTagsFromSource:"volume",
+              snapshots:[]
+            }' > "$result_file"
+        return 0
+    fi
+
+    if ! confirm_action "Create snapshots for $instance_id ($vol_count volume(s))?"; then
+        jq -n --argjson preview "$preview" \
+            '$preview + {status:"skipped",message:"User declined confirmation",snapshots:[]}' > "$result_file"
+        return 1
+    fi
+
+    tag_spec="$(build_tag_specifications)"
+    info "  Calling create-snapshots..."
+    if ! created=$(aws_json ec2 create-snapshots \
+        --instance-specification "InstanceId=$instance_id" \
+        --copy-tags-from-source volume \
+        --description "$desc" \
+        --tag-specifications "$tag_spec"); then
+        jq -n --argjson preview "$preview" --arg msg "create-snapshots failed" \
+            '$preview + {status:"failed",message:$msg,snapshots:[]}' > "$result_file"
+        return 1
+    fi
+
+    snap_json="$(printf '%s' "$created" | jq -c '
+      [.Snapshots[]? | {
+        snapshotId: .SnapshotId,
+        volumeId: (.VolumeId // null),
+        state: (.State // null),
+        description: (.Description // null)
+      }]
+    ')"
+    mapfile -t snapshot_ids < <(printf '%s' "$snap_json" | jq -r '.[].snapshotId // empty' | sanitize_stream)
+
+    success "  Created ${#snapshot_ids[@]} snapshot(s): ${snapshot_ids[*]:-}"
+
+    if [[ "$WAIT_SNAPSHOTS" = true && ${#snapshot_ids[@]} -gt 0 ]]; then
+        info "  Waiting for snapshot completion..."
+        wait_ids="${snapshot_ids[*]}"
+        # shellcheck disable=SC2086
+        if aws_cmd ec2 wait snapshot-completed --snapshot-ids $wait_ids; then
+            success "  Snapshots completed"
+        else
+            error "  Wait failed for one or more snapshots"
+            jq -n --argjson preview "$preview" --argjson snaps "$snap_json" --arg msg "Snapshots created but wait failed" \
+                '$preview + {status:"failed",message:$msg,snapshots:$snaps}' > "$result_file"
+            return 1
+        fi
+    fi
+
+    jq -n --argjson preview "$preview" --argjson snaps "$snap_json" --arg desc "$desc" \
+        '$preview + {
+          status:"success",
+          message:"Snapshots created",
+          description:$desc,
+          copyTagsFromSource:"volume",
+          snapshots:$snaps
+        }' > "$result_file"
+    return 0
+}
+
+write_summary() {
+    local overall="success"
+    local summary
+    if [[ ${#RESULT_FILES[@]} -eq 0 ]]; then
+        error "No results to write"
+        return 1
+    fi
+
+    summary="$(jq -s \
+        --arg accountId "$ACCOUNT_ID" \
+        --arg region "$EFFECTIVE_REGION" \
+        --arg profile "$PROFILE" \
+        --arg generatedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --argjson dryRun "$DRY_RUN" \
+        --arg purpose "$DEFAULT_PURPOSE" \
+        '{
+          accountId: $accountId,
+          region: $region,
+          profile: (if $profile == "" then null else $profile end),
+          generatedAt: $generatedAt,
+          options: {
+            dryRun: $dryRun,
+            defaultPurpose: $purpose,
+            copyTagsFromSource: "volume"
+          },
+          instances: .
+        }' "${RESULT_FILES[@]}")"
+
+    if printf '%s' "$summary" | jq -e '
+      any(.instances[]; .status == "failed" or .status == "skipped")
+    ' >/dev/null; then
+        overall="failed"
+    fi
+
+    mkdir -p "$REPORT_PATH"
+    printf '%s\n' "$(printf '%s' "$summary" | jq '.')" > "$REPORT_PATH/summary.json"
+    info "Wrote $REPORT_PATH/summary.json"
+
+    if [[ "$overall" == "failed" ]]; then
+        return 1
+    fi
+    return 0
+}
+
+print_banner() {
+    echo "" >&2
+    echo "╔════════════════════════════════════════════════════════╗" >&2
+    echo "║          EC2 MANUAL / FINAL SNAPSHOTS                  ║" >&2
+    echo "╚════════════════════════════════════════════════════════╝" >&2
+    echo "" >&2
+}
+
+main() {
+    print_banner
+    check_dependencies
+
+    [[ -n "$PROFILE" ]] && PROFILE_ARG="--profile $PROFILE"
+    [[ -n "$REGION" ]] && REGION_ARG="--region $REGION"
+
+    check_aws_auth
+
+    info "Instance IDs: ${INSTANCE_IDS[*]}"
+    info "Tags to add: $(format_tags_preview)"
+    if [[ "$DRY_RUN" = true ]]; then
+        warning "DRY RUN: no snapshots will be created"
+    fi
+
+    if [[ -z "$REPORT_DIR" ]]; then
+        REPORT_DIR="report/ec2-final-snapshot-$(date +%Y%m%d-%H%M%S)"
+    fi
+    REPORT_PATH="$REPORT_DIR"
+    mkdir -p "$REPORT_PATH"
+
+    local id result_file failures=0
+    for id in "${INSTANCE_IDS[@]}"; do
+        result_file="$(mktemp "$REPORT_PATH/instance-XXXXXX.json")"
+        if ! process_instance "$id" "$result_file"; then
+            failures=$((failures + 1))
+        fi
+        RESULT_FILES+=("$result_file")
+    done
+
+    if write_summary; then
+        success "All instances processed successfully"
+        info "Report: $REPORT_PATH"
+        exit 0
+    else
+        error "Completed with failures or skips ($failures instance(s))"
+        info "Report: $REPORT_PATH"
+        exit 1
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --instance|-i)
+            if [[ -z "${2:-}" || "$2" == --* ]]; then
+                error "Option --instance requires a value"
+                exit 1
+            fi
+            add_instance_ids "$2"
+            shift 2
+            ;;
+        --region|-r)
+            if [[ -z "${2:-}" || "$2" == --* ]]; then
+                error "Option --region requires a value"
+                exit 1
+            fi
+            REGION="$(strip_cr "$2")"
+            shift 2
+            ;;
+        --profile|-p)
+            if [[ -z "${2:-}" || "$2" == --* ]]; then
+                error "Option --profile requires a value"
+                exit 1
+            fi
+            PROFILE="$(strip_cr "$2")"
+            shift 2
+            ;;
+        --tag)
+            if [[ -z "${2:-}" || "$2" == --* ]]; then
+                error "Option --tag requires Key=Value"
+                exit 1
+            fi
+            add_tag "$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --wait)
+            WAIT_SNAPSHOTS=true
+            shift
+            ;;
+        --yes|-y)
+            SKIP_CONFIRM=true
+            shift
+            ;;
+        --report-dir)
+            if [[ -z "${2:-}" || "$2" == --* ]]; then
+                error "Option --report-dir requires a value"
+                exit 1
+            fi
+            REPORT_DIR="$(strip_cr "$2")"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            error "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ${#INSTANCE_IDS[@]} -eq 0 ]]; then
+    error "Missing required argument: --instance / -i"
+    usage
+    exit 1
+fi
+
+dedupe_instances
+main "$@"

--- a/scripts/ec2-final-snapshot.sh
+++ b/scripts/ec2-final-snapshot.sh
@@ -41,9 +41,11 @@ DEFAULT_PURPOSE="manual-final-snapshot"
 
 PROFILE=""
 REGION=""
+MODE="volumes"
 DRY_RUN=false
 WAIT_SNAPSHOTS=false
 SKIP_CONFIRM=false
+NO_REBOOT=false
 REPORT_DIR=""
 ACCOUNT_ID=""
 EFFECTIVE_REGION=""
@@ -60,8 +62,13 @@ usage() {
     cat << EOF
 Usage: $0 --instance <instance-id>[,<instance-id>...] [OPTIONS]
 
-Create crash-consistent EBS snapshots for attached volumes on live EC2 instances
-(aws ec2 create-snapshots). Copies volume tags and adds Purpose=${DEFAULT_PURPOSE}.
+Create intentional final backups for live EC2 instances.
+
+Modes:
+  volumes (default)  aws ec2 create-snapshots — EBS snapshots of attached volumes
+                     (copies volume tags + Purpose=${DEFAULT_PURPOSE})
+  ami                aws ec2 create-image — AMI + backing snapshots (relaunchable)
+                     (tags AMI and all backing snapshots with Purpose + optional --tag)
 
 Does NOT terminate or delete resources. Instance must exist.
 
@@ -69,19 +76,22 @@ Required arguments:
   --instance, -i     One or more instance IDs (repeatable or comma-separated)
 
 Optional arguments:
+  --mode             volumes (default) or ami
   --region, -r       AWS region
   --profile, -p      AWS profile name
-  --tag Key=Value    Extra snapshot tag (repeatable; cannot override Purpose)
-  --dry-run          Preview volumes/tags; do not create snapshots
-  --wait             Wait until each snapshot completes
+  --tag Key=Value    Extra tag (repeatable; cannot override Purpose)
+  --dry-run          Preview only; do not create snapshots or AMIs
+  --wait             Wait until snapshots/AMI become available
+  --no-reboot        AMI mode only: skip reboot (crash-consistent; less safe)
   --yes, -y          Skip confirmation prompt
   --report-dir       Report directory (default: report/ec2-final-snapshot-<timestamp>)
   --help, -h         Show this help message
 
 Examples:
   $0 -i i-0123456789abcdef0 --region us-east-1 --dry-run
-  $0 -i i-aaa --profile prod --tag ChangeTicket=CHG123
-  $0 -i i-aaa -i i-bbb --wait --yes
+  $0 -i i-aaa --mode volumes --tag ChangeTicket=CHG123
+  $0 -i i-aaa --mode ami --wait --yes
+  $0 -i i-aaa --mode ami --no-reboot --dry-run
 
 EOF
 }
@@ -217,7 +227,7 @@ dedupe_instances() {
     INSTANCE_IDS=("${unique[@]}")
 }
 
-build_tag_specifications() {
+build_tags_json() {
     local tags_json i
     tags_json="$(jq -n --arg purpose "$DEFAULT_PURPOSE" '[{Key:"Purpose",Value:$purpose}]')"
     if [[ ${#TAG_KEYS[@]} -gt 0 ]]; then
@@ -226,8 +236,21 @@ build_tag_specifications() {
                 '. + [{Key:$k,Value:$v}]' <<< "$tags_json")"
         done
     fi
-    jq -nc --argjson tags "$tags_json" \
+    printf '%s' "$tags_json"
+}
+
+build_tag_specifications_volumes() {
+    jq -nc --argjson tags "$(build_tags_json)" \
         '[{ResourceType:"snapshot",Tags:$tags}]'
+}
+
+build_tag_specifications_ami() {
+    # Same tags on AMI and all backing snapshots (AWS applies one snapshot tag set to every volume).
+    jq -nc --argjson tags "$(build_tags_json)" \
+        '[
+          {ResourceType:"image",Tags:$tags},
+          {ResourceType:"snapshot",Tags:$tags}
+        ]'
 }
 
 format_tags_preview() {
@@ -239,6 +262,13 @@ format_tags_preview() {
         done
     fi
     printf '%s' "$line"
+}
+
+ami_name_for_instance() {
+    local instance_id="$1"
+    local stamp
+    stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    printf 'final-%s-%s' "$instance_id" "$stamp"
 }
 
 confirm_action() {
@@ -289,33 +319,47 @@ fetch_instance_and_volumes() {
     '
 }
 
-process_instance() {
+fetch_ami_backing_snapshots() {
+    local image_id="$1"
+    local raw
+    if ! raw=$(aws_json_quiet ec2 describe-images --image-ids "$image_id"); then
+        echo '[]'
+        return 0
+    fi
+    printf '%s' "$raw" | jq -c '
+      [.Images[0].BlockDeviceMappings[]?
+        | select(.Ebs.SnapshotId != null)
+        | {
+            snapshotId: .Ebs.SnapshotId,
+            device: (.DeviceName // null),
+            volumeSize: (.Ebs.VolumeSize // null)
+          }
+      ]
+    '
+}
+
+write_failed_result() {
+    local result_file="$1"
+    local instance_id="$2"
+    local msg="$3"
+    jq -n --arg iid "$instance_id" --arg msg "$msg" --arg mode "$MODE" \
+        '{instanceId:$iid,mode:$mode,status:"failed",message:$msg,volumes:[],snapshots:[],ami:null}' \
+        > "$result_file"
+}
+
+process_instance_volumes() {
     local instance_id="$1"
-    local result_file="$2"
-    local preview desc tag_spec created wait_ids snap_json utc status message
+    local preview="$2"
+    local result_file="$3"
+    local desc tag_spec created snap_json wait_ids utc state vol_count
     local -a snapshot_ids=()
 
     utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     desc="Manual final snapshot for ${instance_id} at ${utc}"
-
-    info "Processing $instance_id"
-    if ! preview=$(fetch_instance_and_volumes "$instance_id"); then
-        error "Instance not found or describe-instances failed: $instance_id"
-        jq -n --arg iid "$instance_id" --arg msg "Instance not found or describe-instances failed" \
-            '{instanceId:$iid,status:"failed",message:$msg,volumes:[],snapshots:[]}' > "$result_file"
-        return 1
-    fi
-    if [[ -z "$preview" || "$preview" == "null" ]]; then
-        error "Instance not returned by describe-instances: $instance_id"
-        jq -n --arg iid "$instance_id" --arg msg "Instance not returned by describe-instances" \
-            '{instanceId:$iid,status:"failed",message:$msg,volumes:[],snapshots:[]}' > "$result_file"
-        return 1
-    fi
-
-    local state vol_count
     state="$(printf '%s' "$preview" | jq -r '.state')"
     vol_count="$(printf '%s' "$preview" | jq '.volumes | length')"
 
+    info "  Mode: volumes"
     info "  State: $state"
     info "  Attached volumes: $vol_count"
     printf '%s' "$preview" | jq -r '.volumes[] | "    - \(.volumeId) device=\(.device // "-") deleteOnTermination=\(.deleteOnTermination|tostring)"' >&2
@@ -325,40 +369,43 @@ process_instance() {
 
     if [[ "$vol_count" -eq 0 ]]; then
         warning "  No attached EBS volumes; nothing to snapshot"
-        jq -n --argjson preview "$preview" --arg msg "No attached EBS volumes" \
-            '$preview + {status:"failed",message:$msg,snapshots:[]}' > "$result_file"
+        jq -n --argjson preview "$preview" --arg msg "No attached EBS volumes" --arg mode "$MODE" \
+            '$preview + {mode:$mode,status:"failed",message:$msg,snapshots:[],ami:null}' > "$result_file"
         return 1
     fi
 
     if [[ "$DRY_RUN" = true ]]; then
-        success "  Dry-run: would create snapshots (no changes made)"
-        jq -n --argjson preview "$preview" --arg desc "$desc" --arg tags "$(format_tags_preview)" \
+        success "  Dry-run: would create volume snapshots (no changes made)"
+        jq -n --argjson preview "$preview" --arg desc "$desc" --arg tags "$(format_tags_preview)" --arg mode "$MODE" \
             '$preview + {
+              mode:$mode,
               status:"dry-run",
               message:"Preview only; create-snapshots not called",
               description:$desc,
               tagsToAdd:$tags,
               copyTagsFromSource:"volume",
-              snapshots:[]
+              snapshots:[],
+              ami:null
             }' > "$result_file"
         return 0
     fi
 
-    if ! confirm_action "Create snapshots for $instance_id ($vol_count volume(s))?"; then
-        jq -n --argjson preview "$preview" \
-            '$preview + {status:"skipped",message:"User declined confirmation",snapshots:[]}' > "$result_file"
+    if ! confirm_action "Create volume snapshots for $instance_id ($vol_count volume(s))?"; then
+        jq -n --argjson preview "$preview" --arg mode "$MODE" \
+            '$preview + {mode:$mode,status:"skipped",message:"User declined confirmation",snapshots:[],ami:null}' \
+            > "$result_file"
         return 1
     fi
 
-    tag_spec="$(build_tag_specifications)"
+    tag_spec="$(build_tag_specifications_volumes)"
     info "  Calling create-snapshots..."
     if ! created=$(aws_json ec2 create-snapshots \
         --instance-specification "InstanceId=$instance_id" \
         --copy-tags-from-source volume \
         --description "$desc" \
         --tag-specifications "$tag_spec"); then
-        jq -n --argjson preview "$preview" --arg msg "create-snapshots failed" \
-            '$preview + {status:"failed",message:$msg,snapshots:[]}' > "$result_file"
+        jq -n --argjson preview "$preview" --arg msg "create-snapshots failed" --arg mode "$MODE" \
+            '$preview + {mode:$mode,status:"failed",message:$msg,snapshots:[],ami:null}' > "$result_file"
         return 1
     fi
 
@@ -382,21 +429,202 @@ process_instance() {
             success "  Snapshots completed"
         else
             error "  Wait failed for one or more snapshots"
-            jq -n --argjson preview "$preview" --argjson snaps "$snap_json" --arg msg "Snapshots created but wait failed" \
-                '$preview + {status:"failed",message:$msg,snapshots:$snaps}' > "$result_file"
+            jq -n --argjson preview "$preview" --argjson snaps "$snap_json" --arg msg "Snapshots created but wait failed" --arg mode "$MODE" \
+                '$preview + {mode:$mode,status:"failed",message:$msg,snapshots:$snaps,ami:null}' > "$result_file"
             return 1
         fi
     fi
 
-    jq -n --argjson preview "$preview" --argjson snaps "$snap_json" --arg desc "$desc" \
+    jq -n --argjson preview "$preview" --argjson snaps "$snap_json" --arg desc "$desc" --arg mode "$MODE" \
         '$preview + {
+          mode:$mode,
           status:"success",
           message:"Snapshots created",
           description:$desc,
           copyTagsFromSource:"volume",
-          snapshots:$snaps
+          snapshots:$snaps,
+          ami:null
         }' > "$result_file"
     return 0
+}
+
+process_instance_ami() {
+    local instance_id="$1"
+    local preview="$2"
+    local result_file="$3"
+    local desc ami_name tag_spec created image_id snap_json utc state vol_count reboot_note
+    local create_args=()
+
+    utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    desc="Manual final AMI for ${instance_id} at ${utc}"
+    ami_name="$(ami_name_for_instance "$instance_id")"
+    state="$(printf '%s' "$preview" | jq -r '.state')"
+    vol_count="$(printf '%s' "$preview" | jq '.volumes | length')"
+
+    if [[ "$NO_REBOOT" = true ]]; then
+        reboot_note="no-reboot (crash-consistent; filesystem integrity not guaranteed)"
+    elif [[ "$state" == "running" ]]; then
+        reboot_note="AWS default reboot (running instance will reboot during AMI creation)"
+    else
+        reboot_note="instance is ${state}; AWS will not start a stopped instance for AMI creation"
+    fi
+
+    info "  Mode: ami"
+    info "  State: $state"
+    info "  Attached volumes: $vol_count"
+    printf '%s' "$preview" | jq -r '.volumes[] | "    - \(.volumeId) device=\(.device // "-") deleteOnTermination=\(.deleteOnTermination|tostring)"' >&2
+    info "  AMI name (generated): $ami_name"
+    info "  Reboot behavior: $reboot_note"
+    info "  Copy volume tags: no (AMI API limitation; Purpose + --tag applied to AMI and all backing snapshots)"
+    info "  Tags to add: $(format_tags_preview)"
+    info "  Description: $desc"
+
+    if [[ "$vol_count" -eq 0 ]]; then
+        warning "  No attached EBS volumes; cannot create EBS-backed AMI"
+        jq -n --argjson preview "$preview" --arg msg "No attached EBS volumes" --arg mode "$MODE" \
+            '$preview + {mode:$mode,status:"failed",message:$msg,snapshots:[],ami:null}' > "$result_file"
+        return 1
+    fi
+
+    if [[ "$DRY_RUN" = true ]]; then
+        success "  Dry-run: would create AMI (no changes made)"
+        jq -n \
+            --argjson preview "$preview" \
+            --arg desc "$desc" \
+            --arg tags "$(format_tags_preview)" \
+            --arg mode "$MODE" \
+            --arg amiName "$ami_name" \
+            --arg reboot "$reboot_note" \
+            --argjson noReboot "$NO_REBOOT" \
+            '$preview + {
+              mode:$mode,
+              status:"dry-run",
+              message:"Preview only; create-image not called",
+              description:$desc,
+              tagsToAdd:$tags,
+              copyTagsFromSource:null,
+              rebootBehavior:$reboot,
+              noReboot:$noReboot,
+              snapshots:[],
+              ami:{imageId:null,name:$amiName,state:null}
+            }' > "$result_file"
+        return 0
+    fi
+
+    if ! confirm_action "Create AMI for $instance_id ($vol_count volume(s))? $reboot_note"; then
+        jq -n --argjson preview "$preview" --arg mode "$MODE" \
+            '$preview + {mode:$mode,status:"skipped",message:"User declined confirmation",snapshots:[],ami:null}' \
+            > "$result_file"
+        return 1
+    fi
+
+    tag_spec="$(build_tag_specifications_ami)"
+    create_args=(
+        ec2 create-image
+        --instance-id "$instance_id"
+        --name "$ami_name"
+        --description "$desc"
+        --tag-specifications "$tag_spec"
+    )
+    if [[ "$NO_REBOOT" = true ]]; then
+        create_args+=(--no-reboot)
+    fi
+
+    info "  Calling create-image..."
+    if ! created=$(aws_json "${create_args[@]}"); then
+        jq -n --argjson preview "$preview" --arg msg "create-image failed" --arg mode "$MODE" \
+            '$preview + {mode:$mode,status:"failed",message:$msg,snapshots:[],ami:null}' > "$result_file"
+        return 1
+    fi
+
+    image_id="$(printf '%s' "$created" | jq -r '.ImageId // empty' | tr -d '\r')"
+    if [[ -z "$image_id" ]]; then
+        error "  create-image returned no ImageId"
+        jq -n --argjson preview "$preview" --arg msg "create-image returned no ImageId" --arg mode "$MODE" \
+            '$preview + {mode:$mode,status:"failed",message:$msg,snapshots:[],ami:null}' > "$result_file"
+        return 1
+    fi
+    success "  Created AMI: $image_id ($ami_name)"
+
+    if [[ "$WAIT_SNAPSHOTS" = true ]]; then
+        info "  Waiting for AMI to become available..."
+        if aws_cmd ec2 wait image-available --image-ids "$image_id"; then
+            success "  AMI available"
+        else
+            error "  Wait failed for AMI $image_id"
+            snap_json="$(fetch_ami_backing_snapshots "$image_id")"
+            jq -n \
+                --argjson preview "$preview" \
+                --argjson snaps "$snap_json" \
+                --arg imageId "$image_id" \
+                --arg amiName "$ami_name" \
+                --arg msg "AMI created but wait failed" \
+                --arg mode "$MODE" \
+                --arg reboot "$reboot_note" \
+                --argjson noReboot "$NO_REBOOT" \
+                '$preview + {
+                  mode:$mode,
+                  status:"failed",
+                  message:$msg,
+                  rebootBehavior:$reboot,
+                  noReboot:$noReboot,
+                  snapshots:$snaps,
+                  ami:{imageId:$imageId,name:$amiName,state:"pending"}
+                }' > "$result_file"
+            return 1
+        fi
+    fi
+
+    snap_json="$(fetch_ami_backing_snapshots "$image_id")"
+    jq -n \
+        --argjson preview "$preview" \
+        --argjson snaps "$snap_json" \
+        --arg desc "$desc" \
+        --arg imageId "$image_id" \
+        --arg amiName "$ami_name" \
+        --arg mode "$MODE" \
+        --arg reboot "$reboot_note" \
+        --argjson noReboot "$NO_REBOOT" \
+        '$preview + {
+          mode:$mode,
+          status:"success",
+          message:"AMI created",
+          description:$desc,
+          copyTagsFromSource:null,
+          rebootBehavior:$reboot,
+          noReboot:$noReboot,
+          snapshots:$snaps,
+          ami:{imageId:$imageId,name:$amiName,state:null}
+        }' > "$result_file"
+    return 0
+}
+
+process_instance() {
+    local instance_id="$1"
+    local result_file="$2"
+    local preview
+
+    info "Processing $instance_id"
+    if ! preview=$(fetch_instance_and_volumes "$instance_id"); then
+        error "Instance not found or describe-instances failed: $instance_id"
+        write_failed_result "$result_file" "$instance_id" "Instance not found or describe-instances failed"
+        return 1
+    fi
+    if [[ -z "$preview" || "$preview" == "null" ]]; then
+        error "Instance not returned by describe-instances: $instance_id"
+        write_failed_result "$result_file" "$instance_id" "Instance not returned by describe-instances"
+        return 1
+    fi
+
+    case "$MODE" in
+        volumes) process_instance_volumes "$instance_id" "$preview" "$result_file" ;;
+        ami) process_instance_ami "$instance_id" "$preview" "$result_file" ;;
+        *)
+            error "Invalid mode: $MODE"
+            write_failed_result "$result_file" "$instance_id" "Invalid mode"
+            return 1
+            ;;
+    esac
 }
 
 write_summary() {
@@ -414,15 +642,19 @@ write_summary() {
         --arg generatedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
         --argjson dryRun "$DRY_RUN" \
         --arg purpose "$DEFAULT_PURPOSE" \
+        --arg mode "$MODE" \
+        --argjson noReboot "$NO_REBOOT" \
         '{
           accountId: $accountId,
           region: $region,
           profile: (if $profile == "" then null else $profile end),
           generatedAt: $generatedAt,
           options: {
+            mode: $mode,
             dryRun: $dryRun,
             defaultPurpose: $purpose,
-            copyTagsFromSource: "volume"
+            noReboot: $noReboot,
+            copyTagsFromSource: (if $mode == "volumes" then "volume" else null end)
           },
           instances: .
         }' "${RESULT_FILES[@]}")"
@@ -460,10 +692,20 @@ main() {
 
     check_aws_auth
 
+    info "Mode: $MODE"
     info "Instance IDs: ${INSTANCE_IDS[*]}"
     info "Tags to add: $(format_tags_preview)"
+    if [[ "$MODE" == "ami" ]]; then
+        if [[ "$NO_REBOOT" = true ]]; then
+            warning "AMI mode: --no-reboot set (crash-consistent)"
+        else
+            info "AMI mode: running instances will reboot by default during create-image"
+        fi
+    elif [[ "$NO_REBOOT" = true ]]; then
+        warning "--no-reboot is ignored in volumes mode"
+    fi
     if [[ "$DRY_RUN" = true ]]; then
-        warning "DRY RUN: no snapshots will be created"
+        warning "DRY RUN: no snapshots or AMIs will be created"
     fi
 
     if [[ -z "$REPORT_DIR" ]]; then
@@ -502,6 +744,21 @@ while [[ $# -gt 0 ]]; do
             add_instance_ids "$2"
             shift 2
             ;;
+        --mode)
+            if [[ -z "${2:-}" || "$2" == --* ]]; then
+                error "Option --mode requires a value (volumes|ami)"
+                exit 1
+            fi
+            MODE="$(strip_cr "$2" | tr '[:upper:]' '[:lower:]')"
+            case "$MODE" in
+                volumes|ami) ;;
+                *)
+                    error "Invalid mode: $MODE (expected volumes or ami)"
+                    exit 1
+                    ;;
+            esac
+            shift 2
+            ;;
         --region|-r)
             if [[ -z "${2:-}" || "$2" == --* ]]; then
                 error "Option --region requires a value"
@@ -532,6 +789,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --wait)
             WAIT_SNAPSHOTS=true
+            shift
+            ;;
+        --no-reboot)
+            NO_REBOOT=true
             shift
             ;;
         --yes|-y)

--- a/scripts/ec2-final-snapshot.sh
+++ b/scripts/ec2-final-snapshot.sh
@@ -264,11 +264,53 @@ format_tags_preview() {
     printf '%s' "$line"
 }
 
+sanitize_ami_name_component() {
+    # AMI names allow: letters, digits, spaces, and ()./_-
+    # We normalize whitespace to '-' and drop unsupported characters.
+    local raw="$1"
+    local cleaned
+    cleaned="$(printf '%s' "$raw" | tr -d '\r')"
+    cleaned="$(printf '%s' "$cleaned" | sed -E \
+        -e 's/[[:space:]]+/-/g' \
+        -e 's/[^A-Za-z0-9()._/-]/-/g' \
+        -e 's/-+/-/g' \
+        -e 's/^-+//' \
+        -e 's/-+$//')"
+    printf '%s' "$cleaned"
+}
+
 ami_name_for_instance() {
     local instance_id="$1"
-    local stamp
-    stamp="$(date -u +%Y%m%dT%H%M%SZ)"
-    printf 'final-%s-%s' "$instance_id" "$stamp"
+    local name_tag="${2:-}"
+    local stamp sanitized_name fixed_suffix fixed_len max_name_len name_part
+    stamp="$(date -u +%Y%m%d-%H%M%S)"
+    fixed_suffix="-${instance_id}-${stamp}-final"
+    fixed_len="${#fixed_suffix}"
+
+    # AWS AMI name max length is 128. Keep instance id, stamp, and -final intact.
+    if [[ "$fixed_len" -ge 128 ]]; then
+        printf '%s' "${instance_id}-${stamp}-final" | cut -c1-128
+        return 0
+    fi
+
+    sanitized_name="$(sanitize_ami_name_component "$name_tag")"
+    if [[ -z "$sanitized_name" ]]; then
+        printf '%s' "${instance_id}-${stamp}-final"
+        return 0
+    fi
+
+    max_name_len=$((128 - fixed_len))
+    if [[ "$max_name_len" -lt 1 ]]; then
+        printf '%s' "${instance_id}-${stamp}-final" | cut -c1-128
+        return 0
+    fi
+    name_part="$(printf '%s' "$sanitized_name" | cut -c1-"$max_name_len")"
+    name_part="$(printf '%s' "$name_part" | sed -E 's/-+$//')"
+    if [[ -z "$name_part" ]]; then
+        printf '%s' "${instance_id}-${stamp}-final"
+        return 0
+    fi
+    printf '%s%s' "$name_part" "$fixed_suffix"
 }
 
 confirm_action() {
@@ -304,6 +346,9 @@ fetch_instance_and_volumes() {
             instanceId: $iid,
             state: ($inst.State.Name // "unknown"),
             instanceType: ($inst.InstanceType // null),
+            nameTag: (
+              (($inst.Tags // []) | map(select(.Key == "Name")) | .[0].Value) // null
+            ),
             volumes: (
               [$inst.BlockDeviceMappings[]?
                 | select(.Ebs.VolumeId != null)
@@ -452,12 +497,13 @@ process_instance_ami() {
     local instance_id="$1"
     local preview="$2"
     local result_file="$3"
-    local desc ami_name tag_spec created image_id snap_json utc state vol_count reboot_note
+    local desc ami_name tag_spec created image_id snap_json utc state vol_count reboot_note name_tag
     local create_args=()
 
     utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     desc="Manual final AMI for ${instance_id} at ${utc}"
-    ami_name="$(ami_name_for_instance "$instance_id")"
+    name_tag="$(printf '%s' "$preview" | jq -r '.nameTag // empty' | tr -d '\r')"
+    ami_name="$(ami_name_for_instance "$instance_id" "$name_tag")"
     state="$(printf '%s' "$preview" | jq -r '.state')"
     vol_count="$(printf '%s' "$preview" | jq '.volumes | length')"
 
@@ -471,6 +517,7 @@ process_instance_ami() {
 
     info "  Mode: ami"
     info "  State: $state"
+    info "  Name tag: ${name_tag:-<none>}"
     info "  Attached volumes: $vol_count"
     printf '%s' "$preview" | jq -r '.volumes[] | "    - \(.volumeId) device=\(.device // "-") deleteOnTermination=\(.deleteOnTermination|tostring)"' >&2
     info "  AMI name (generated): $ami_name"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements intentional EC2 manual/final backups as a day-to-day ops practice (not elimination-only).

### Practice + section framing (#21 / #22)

- New [`ec2/manual-snapshots.md`](ec2/manual-snapshots.md): when/why, consistency, snapshot vs AMI, tagging, retention, helper usage
- Reframe [`ec2/README.md`](ec2/README.md) as day-to-day ops with room for multiple guides
- Wire root README, scripts index, and elimination checklist

### Helper (`scripts/ec2-final-snapshot.sh`)

**`--mode volumes` (default)**
- `aws ec2 create-snapshots` per live instance (crash-consistent)
- `--copy-tags-from-source volume`
- Default tag only: `Purpose=manual-final-snapshot`
- Optional `--tag Key=Value`

**`--mode ami`**
- `aws ec2 create-image` (AMI + backing snapshots)
- Running instances **reboot by default** (AWS default); stopped stay stopped
- Explicit `--no-reboot` for crash-consistent AMI
- AMI name generated inside the script (no user `--name` flag)
- `Purpose` + optional `--tag` applied to AMI and all backing snapshots
- Note: AMI API cannot copy per-volume tags

**Shared**
- `--dry-run` (preview only), `--wait`, `--yes`, JSON report
- Per-instance success/failure; non-zero if any fail/skip
- Does **not** terminate or delete

Closes #21  
Closes #22

## Test plan

- [x] `bash -n scripts/ec2-final-snapshot.sh`
- [x] `--help`, invalid `--mode`, Purpose override rejection
- [x] Relative doc links resolve
- [x] Dry-run volumes + ami against a real instance
- [x] Live volumes run; verify copied volume tags + Purpose
- [x] Live ami run on a non-prod instance; confirm reboot behavior and tags on AMI/snapshots
- [x] Skim rendered docs on GitHub
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f188cde4-bc70-477c-ab5a-d2e0dc365992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f188cde4-bc70-477c-ab5a-d2e0dc365992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

