### PR TITLE
docs(auth): document SSO sso-session and legacy config methods

### DIFF
--- a/auth/iam-identity-center.md
+++ b/auth/iam-identity-center.md
@@ -1,6 +1,7 @@
 # IAM Identity Center
 
 - [AWS IAM Identity Center FAQs](https://aws.amazon.com/iam/identity-center/faqs/)
+- [IAM Identity Center User Guide](https://docs.aws.amazon.com/singlesignon/latest/userguide/what-is.html)
 - [Organization instances of IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/organization-instances-identity-center.html)
 - [Account instances of IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/account-instances-identity-center.html)
 - [To enable an instance of IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/enable-identity-center.html#to-enable-identity-center-instance)

--- a/auth/sso.md
+++ b/auth/sso.md
@@ -78,11 +78,4 @@ aws sts get-caller-identity --profile account-a
 
 ## Scripts
 
-- [`auth/scripts/sso-profiles-check.sh`](./scripts/sso-profiles-check.sh) — validate local SSO profiles can authenticate
-
-## Related references
-
-- [Configuring the AWS CLI to use IAM Identity Center](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html)
-- [IAM Identity Center User Guide](https://docs.aws.amazon.com/singlesignon/latest/userguide/what-is.html)
-- [AWS IAM Identity Center FAQs](https://aws.amazon.com/iam/identity-center/faqs/)
-- [IAM Identity Center](./iam-identity-center.md) — instance types and enablement refs
+- [`sso-profiles-check.sh`](./scripts/sso-profiles-check.sh) — validate local SSO profiles can authenticate

--- a/auth/sso.md
+++ b/auth/sso.md
@@ -2,9 +2,7 @@
 
 AWS Single Sign-On (SSO) / IAM Identity Center is the recommended way to authenticate to AWS for organizations with multiple accounts.
 
-## Overview
-
-AWS SSO provides centralized authentication and authorization across AWS accounts in AWS Organizations.
+SSO provides centralized authentication and authorization across AWS accounts in AWS Organizations.
 
 ## Prerequisites
 
@@ -12,8 +10,79 @@ AWS SSO provides centralized authentication and authorization across AWS account
 - IAM Identity Center enabled
 - SSO users and/or groups created
 
-## Related Links
+## Config file
 
-- [AWS IAM Identity Center FAQs](https://aws.amazon.com/iam/identity-center/faqs/)
+SSO profile settings belong in `~/.aws/config`.
+
+## Method 1 — Recommended (`sso-session`)
+
+Share one `[sso-session …]` across accounts, then point each named profile at that session with its own account and role.
+
+```ini
+# ~/.aws/config
+
+[sso-session my-sso]
+sso_start_url = https://my-sso-portal.awsapps.com/start
+sso_region = us-east-1
+sso_registration_scopes = sso:account:access
+
+[profile account-a]
+sso_session = my-sso
+sso_account_id = 111122223333
+sso_role_name = AdministratorAccess
+region = us-east-1
+
+[profile account-b]
+sso_session = my-sso
+sso_account_id = 444455556666
+sso_role_name = ReadOnlyAccess
+region = us-west-2
+```
+
+Login once for the session (or via any profile that uses it):
+
+```shell
+aws sso login --sso-session my-sso
+# or
+aws sso login --profile account-a
+```
+
+Verify:
+
+```shell
+aws sts get-caller-identity --profile account-a
+aws sts get-caller-identity --profile account-b
+```
+
+## Method 2 — Legacy (inline profile keys)
+
+Put all `sso_*` keys on each `[profile …]` when you are not using an `sso-session` block.
+
+```ini
+# ~/.aws/config
+
+[profile account-a]
+sso_start_url = https://my-sso-portal.awsapps.com/start
+sso_region = us-east-1
+sso_account_id = 111122223333
+sso_role_name = AdministratorAccess
+region = us-east-1
+```
+
+Login and verify:
+
+```shell
+aws sso login --profile account-a
+aws sts get-caller-identity --profile account-a
+```
+
+## Scripts
+
+- [`auth/scripts/sso-profiles-check.sh`](./scripts/sso-profiles-check.sh) — validate local SSO profiles can authenticate
+
+## Related references
+
+- [Configuring the AWS CLI to use IAM Identity Center](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html)
 - [IAM Identity Center User Guide](https://docs.aws.amazon.com/singlesignon/latest/userguide/what-is.html)
-- [Configuring the AWS CLI to use IAM Identity Center](https://docs.aws.amazon.com/cli/latest/userguide/sso-configure-profile.html)
+- [AWS IAM Identity Center FAQs](https://aws.amazon.com/iam/identity-center/faqs/)
+- [IAM Identity Center](./iam-identity-center.md) — instance types and enablement refs

--- a/cli/sso.md
+++ b/cli/sso.md
@@ -1,11 +1,11 @@
 # SSO
 
-Profile layouts (`sso-session` and legacy inline): see [auth/sso.md](../auth/sso.md).
+AWS CLI commands for IAM Identity Center sign-in and cached credentials.
+
+https://docs.aws.amazon.com/cli/latest/reference/sso/
 
 ```shell
 aws sso login --sso-session <session>
 aws sso login --profile <profile>
 aws sso logout
-aws sts get-caller-identity --profile <profile>
-aws sso-admin list-instances
 ```

--- a/cli/sso.md
+++ b/cli/sso.md
@@ -1,5 +1,11 @@
 # SSO
 
+Profile layouts (`sso-session` and legacy inline): see [auth/sso.md](../auth/sso.md).
+
 ```shell
+aws sso login --sso-session <session>
+aws sso login --profile <profile>
+aws sso logout
+aws sts get-caller-identity --profile <profile>
 aws sso-admin list-instances
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the two official AWS CLI SSO / IAM Identity Center profile layouts, and keeps Identity Center reference links on a single page.

Rebased onto latest `main` (includes #32 script bug fixes and #34 `AGENTS.md`).

## Changes

- Expand [`auth/sso.md`](auth/sso.md):
  - Config file note (`~/.aws/config`)
  - Method 1 — recommended `sso-session` + multi-account profiles
  - Method 2 — legacy inline `sso_*` keys
  - Login / verify examples
  - `Scripts` section with filename-only link
  - No Related references (avoids duplicating Identity Center links)
- Expand [`auth/iam-identity-center.md`](auth/iam-identity-center.md) as the Identity Center reference hub (FAQ, User Guide, instance docs)
- Tighten [`cli/sso.md`](cli/sso.md): brief prose, official `aws sso` reference, login/logout commands only

## Out of scope

- No changes to `auth/scripts/sso-profiles-check.sh` (bug fixes landed in #32)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b7380c1-41ed-42db-80fe-c2b39b67ba09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b7380c1-41ed-42db-80fe-c2b39b67ba09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

