### PR TITLE
fix(auth): sso-profiles-check bug fixes

### DIFF
--- a/auth/scripts/sso-profiles-check.sh
+++ b/auth/scripts/sso-profiles-check.sh
@@ -6,6 +6,9 @@ AWS_CREDENTIALS_FILE="$HOME/.aws/credentials"
 AWS_CONFIG_FILE="$HOME/.aws/config"
 AWS_ENV_VARS=("AWS_ACCESS_KEY_ID" "AWS_SECRET_ACCESS_KEY" "AWS_SESSION_TOKEN")
 
+TMPFILE=""
+trap 'rm -f "$TMPFILE"' EXIT
+
 echo "#========================================#"
 echo "#     AWS SSO PROFILES CHECK SCRIPT      #"
 echo "#========================================#"
@@ -30,7 +33,13 @@ check_aws_cli() {
         log_error "AWS CLI is not installed or not in PATH"
         exit 1
     fi
-    log_ok "AWS CLI: $(aws --version 2>&1 | grep -oP "aws-cli/\d+\.\d+\.\d+" || echo "installed")"
+    local ver
+    ver=$(aws --version 2>&1)
+    if [[ "$ver" =~ aws-cli/([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+        log_ok "AWS CLI: aws-cli/${BASH_REMATCH[1]}"
+    else
+        log_ok "AWS CLI: installed"
+    fi
 }
 
 _mask() {
@@ -70,13 +79,12 @@ check_aws_env_vars() {
 check_sso_session() {
     log_info "Verifying AWS SSO session..."
 
-    if ! aws sts get-caller-identity &> /dev/null; then
+    local identity
+    if ! identity=$(aws sts get-caller-identity --query "Arn" --output text 2>/dev/null); then
         log_error "No active SSO session. Please run 'aws sso login' and try again."
         exit 1
     fi
 
-    local identity
-    identity=$(aws sts get-caller-identity --query "Arn" --output text 2>/dev/null)
     log_ok "SSO session active: $identity"
 }
 
@@ -90,8 +98,10 @@ get_profiles_from_config() {
 
     while IFS= read -r line; do
         line=$(echo "$line" | tr -d '\r')
-        local profile_name
-        profile_name=$(echo "$line" | grep -oP '^\[profile\s+\K[^\]]+' || true)
+        local profile_name=""
+        if [[ "$line" =~ ^\[profile[[:space:]]+([^\]]+)\] ]]; then
+            profile_name="${BASH_REMATCH[1]}"
+        fi
         if [ -n "$profile_name" ] && [ "$profile_name" != "default" ]; then
             profiles+=("$profile_name")
         fi
@@ -220,9 +230,8 @@ main() {
     local success_count=0
     local failure_count=0
 
-    local tmpfile
-    tmpfile=$(mktemp)
-    echo "$all_profiles" > "$tmpfile"
+    TMPFILE=$(mktemp)
+    echo "$all_profiles" > "$TMPFILE"
 
     while IFS= read -r profile || [ -n "$profile" ]; do
         [ -z "$profile" ] && continue
@@ -239,11 +248,12 @@ main() {
             export AWS_PROFILE="$profile"
             local account_id
             account_id=$(aws configure get sso_account_id 2>/dev/null) || account_id="<unknown>"
-            printf "${RED}[FAIL]${RESET} %-12s | %-20s | %s - failed to authenticate\n" "$account_id" "$profile" "$profile"
+            printf "${RED}[FAIL]${RESET} %-12s | %-20s | %s - failed to authenticate\n" "$account_id" "<no-alias>" "$profile"
         fi
-    done < "$tmpfile"
+    done < "$TMPFILE"
 
-    rm -f "$tmpfile"
+    rm -f "$TMPFILE"
+    TMPFILE=""
 
     echo ""
     echo "---"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bug-fix-only pass on `auth/scripts/sso-profiles-check.sh`. Discovery model and the default-identity pre-check are unchanged in this pass (a later migration plan will address those).

## Changes

- **FAIL printf columns** — the failure line printed the profile name twice; the middle column now shows `<no-alias>` to match the success line's `account_id | alias | profile` layout
- **Portable regex** — replaced GNU-only `grep -oP` (PCRE, `\K`) with bash `[[ =~ ]]` / `BASH_REMATCH` at both call sites (version parse and profile-name extraction) so the script runs on macOS stock grep
- **tmpfile cleanup trap** — added a global `TMPFILE` and `trap 'rm -f "$TMPFILE"' EXIT` so the mktemp file is removed on `set -e` early exit
- **Single STS call** — `check_sso_session` now calls `aws sts get-caller-identity` once instead of twice (avoids a mid-check expiry race)

## Verification

- `bash -n` syntax check passes
- Sample-config extraction test confirms `[default]` is skipped and named profiles are captured

## Out of scope (later)

- SSO-aware discovery from `~/.aws/config` only
- Dropping credentials-file SSO scanning
- Replacing the default-identity pre-check
- `sso-session` (Method 1) structure support
- Respecting `AWS_CONFIG_FILE` / `AWS_SHARED_CREDENTIALS_FILE` env vars

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b7380c1-41ed-42db-80fe-c2b39b67ba09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b7380c1-41ed-42db-80fe-c2b39b67ba09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

