### PR TITLE
feat(scripts): backfill --help on scripts missing it

### DIFF
--- a/auth/scripts/sso-profiles-check.sh
+++ b/auth/scripts/sso-profiles-check.sh
@@ -9,16 +9,23 @@ AWS_ENV_VARS=("AWS_ACCESS_KEY_ID" "AWS_SECRET_ACCESS_KEY" "AWS_SESSION_TOKEN")
 TMPFILE=""
 trap 'rm -f "$TMPFILE"' EXIT
 
-echo "#========================================#"
-echo "#     AWS SSO PROFILES CHECK SCRIPT      #"
-echo "#========================================#"
-echo ""
-
 if [ -t 1 ]; then
   GREEN="\e[32m"; YELLOW="\e[33m"; BLUE="\e[34m"; RED="\e[31m"; GRAY="\e[90m"; RESET="\e[0m"
 else
   GREEN=""; YELLOW=""; BLUE=""; RED=""; GRAY=""; RESET=""
 fi
+
+usage() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+Validate local AWS SSO profiles can authenticate (STS + account alias).
+
+Options:
+  --help, -h         Show this help message
+
+EOF
+}
 
 now() { date +"%Y-%m-%d %H:%M:%S"; }
 
@@ -189,6 +196,25 @@ validate_profile() {
 }
 
 main() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --help|-h)
+                usage
+                exit 0
+                ;;
+            *)
+                echo "Error: unknown option: $1" >&2
+                usage >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    echo "#========================================#"
+    echo "#     AWS SSO PROFILES CHECK SCRIPT      #"
+    echo "#========================================#"
+    echo ""
+
     check_aws_cli
     check_aws_env_vars
     check_sso_session

--- a/dev-tools/scripts/aws-dev-tools-report.sh
+++ b/dev-tools/scripts/aws-dev-tools-report.sh
@@ -2,23 +2,44 @@
 
 set -euo pipefail
 
-# Parse arguments
+usage() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+Generate CSV reports for AWS developer tools (CodeCommit, CodeArtifact,
+CodeBuild, CodeDeploy, CodePipeline) in the current account.
+
+Options:
+  --xlsx             Convert CSV reports to a single XLSX (requires uv)
+  --help, -h         Show this help message
+
+EOF
+}
+
 XLSX_MODE=false
-if [ $# -gt 0 ] && [ "$1" = "--xlsx" ]; then
-    XLSX_MODE=true
-fi
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --xlsx)
+            XLSX_MODE=true
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
 
 # Array to track generated reports
 generated=()
 
 TIMESTAMP=$(date '+%Y%m%d%H%M%S')
 REPORT_DIR="aws_report_$(date '+%Y%m%d')"
-
-
-check_aws_cli() {
-  if !
-}
-
 
 echo "############################################"
 echo "#   AWS Developer Tools Report Generator   #"

--- a/scripts/s3-bucket-object.sh
+++ b/scripts/s3-bucket-object.sh
@@ -2,6 +2,20 @@
 
 set -euo pipefail
 
+usage() {
+  cat << EOF
+Usage: $0 [OPTIONS]
+
+List S3 buckets and object counts in the current AWS account (read-only).
+
+Requires: aws CLI, jq
+
+Options:
+  --help, -h         Show this help message
+
+EOF
+}
+
 check_dependencies() {
   if ! command -v aws > /dev/null; then
     echo "Error: aws-cli is not installed or not in PATH."
@@ -41,6 +55,20 @@ get_bucket_objects() {
 }
 
 main() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      --help|-h)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "Error: unknown option: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+
   echo "################################"
   echo "#    AWS S3 BUCKETS OBJECTS    #"
   echo "################################"
@@ -51,4 +79,4 @@ main() {
   get_bucket_objects
 }
 
-main
+main "$@"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Brings the three scripts that lacked `--help` / `-h` in line with [AGENTS.md](AGENTS.md) Code Standards.

## Changes

- [`auth/scripts/sso-profiles-check.sh`](auth/scripts/sso-profiles-check.sh) — `usage()`, arg parse before banner, `--help`/`-h`
- [`scripts/s3-bucket-object.sh`](scripts/s3-bucket-object.sh) — `usage()`, `main "$@"`, `--help`/`-h`
- [`dev-tools/scripts/aws-dev-tools-report.sh`](dev-tools/scripts/aws-dev-tools-report.sh) — `usage()`, replace `--xlsx`-only parse with a case loop including `--help`/`-h`; remove broken unused `check_aws_cli` stub (syntax error that broke `bash -n`)

## Verification

- `bash -n` passes on all three
- `--help` / `-h` exit 0 and print usage (no AWS calls / no SSO banner)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b7380c1-41ed-42db-80fe-c2b39b67ba09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b7380c1-41ed-42db-80fe-c2b39b67ba09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

