### PR TITLE
docs: slim root README to intro, TOC table, and script note

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,6 @@ A personal wiki of AWS knowledge: CLI cheat sheets, operational guides, and help
 
 Each directory README is the index for its own pages; this file links to sections only.
 
-## Prerequisites
-
-- [AWS CLI v2](./cli/install/README.md) — install notes and first-time setup
-- `jq` — required by several scripts
-- [mise](https://mise.jdx.dev/) — optional; `mise.toml` pins Steampipe and provides `mise t` to list the tools installed for this directory
-
 ## Running the scripts
 
 Write scripts are marked **write** in [scripts/README.md](./scripts/README.md) and support `--dry-run` where practical. Run them with `--dry-run` first, and pass an explicit `--profile` / `--region` rather than relying on shell defaults.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ A personal wiki of AWS knowledge: CLI cheat sheets, operational guides, and help
 | [dev-tools/](./dev-tools/README.md) | CodeCommit, CodeBuild, CodePipeline, reporting scripts |
 | [scripts/](./scripts/README.md) | Helper scripts, each marked read-only or write |
 
-Each directory README is the index for its own pages; this file links to sections only.
-
 ## Running the scripts
 
 Write scripts are marked **write** in [scripts/README.md](./scripts/README.md) and support `--dry-run` where practical. Run them with `--dry-run` first, and pass an explicit `--profile` / `--region` rather than relying on shell defaults.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A personal wiki of AWS knowledge: CLI cheat sheets, operational guides, and helper scripts, collected from real-world usage.
 
-## Sections
-
 | Section | What's inside |
 |---------|---------------|
 | [auth/](./auth/README.md) | IAM users, AWS SSO, IAM Identity Center |

--- a/README.md
+++ b/README.md
@@ -26,10 +26,3 @@ Each directory README is the index for its own pages; this file links to section
 ## Running the scripts
 
 Write scripts are marked **write** in [scripts/README.md](./scripts/README.md) and support `--dry-run` where practical. Run them with `--dry-run` first, and pass an explicit `--profile` / `--region` rather than relying on shell defaults.
-
-## Conventions
-
-- Every directory has a `README.md` that indexes its pages.
-- Each page under `cli/` maps to an `aws` subcommand or service area.
-- Link lists use a markdown link to the page, followed by an em dash and a short description.
-- Commits follow [Conventional Commits](https://www.conventionalcommits.org/), for example `docs(ec2):` or `feat(scripts):`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Slims the root [`README.md`](README.md) to a high-level index: intro, TOC table, and a short script-usage note. Development rules live in [`AGENTS.md`](AGENTS.md).

## Changes

- Delete `## Conventions`
- Delete `## Prerequisites`
- Delete the directory-README index sentence
- Drop the `## Sections` heading (TOC table sits under the intro)
- Leave the section table and Running the scripts unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b7380c1-41ed-42db-80fe-c2b39b67ba09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b7380c1-41ed-42db-80fe-c2b39b67ba09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

