### PR TITLE
fix(auth): align SSO profiles check table columns dynamically

### DIFF
--- a/auth/scripts/sso-profiles-check.sh
+++ b/auth/scripts/sso-profiles-check.sh
@@ -354,6 +354,10 @@ run_validate() {
 
     local success_count=0
     local failure_count=0
+    local w_account=0
+    local w_alias=0
+    local w_profile=0
+    local display_rows=""
 
     TMPFILE=$(mktemp)
     printf '%s\n' "$rows" > "$TMPFILE"
@@ -363,23 +367,44 @@ run_validate() {
         local profile method session account_cfg role
         IFS='|' read -r profile method session account_cfg role <<< "$row"
 
+        local status account_id alias message
         local result
         if result=$(validate_profile "$profile"); then
             success_count=$((success_count + 1))
-            local account_id alias
+            status="OK"
             account_id=$(echo "$result" | cut -d'|' -f1)
             alias=$(echo "$result" | cut -d'|' -f2)
-            printf "${GREEN}[OK]${RESET} %-12s | %-20s | %s - authenticated successfully\n" "$account_id" "$alias" "$profile"
+            message="authenticated successfully"
         else
             failure_count=$((failure_count + 1))
-            local account_id="${account_cfg:-<unknown>}"
+            status="FAIL"
+            account_id="${account_cfg:-<unknown>}"
             [ -z "$account_id" ] && account_id="<unknown>"
-            printf "${RED}[FAIL]${RESET} %-12s | %-20s | %s - failed to authenticate\n" "$account_id" "<no-alias>" "$profile"
+            alias="<no-alias>"
+            message="failed to authenticate"
         fi
+
+        w_account=$(_col_width "$w_account" "$account_id")
+        w_alias=$(_col_width "$w_alias" "$alias")
+        w_profile=$(_col_width "$w_profile" "$profile")
+        display_rows+="${status}|${account_id}|${alias}|${profile}|${message}"$'\n'
     done < "$TMPFILE"
 
     rm -f "$TMPFILE"
     TMPFILE=""
+
+    while IFS= read -r row || [ -n "$row" ]; do
+        [ -z "$row" ] && continue
+        local status account_id alias profile message
+        IFS='|' read -r status account_id alias profile message <<< "$row"
+        if [ "$status" = "OK" ]; then
+            printf "${GREEN}%-6s${RESET} %-*s | %-*s | %-*s - %s\n" \
+                "[OK]" "$w_account" "$account_id" "$w_alias" "$alias" "$w_profile" "$profile" "$message"
+        else
+            printf "${RED}%-6s${RESET} %-*s | %-*s | %-*s - %s\n" \
+                "[FAIL]" "$w_account" "$account_id" "$w_alias" "$alias" "$w_profile" "$profile" "$message"
+        fi
+    done <<< "$display_rows"
 
     echo ""
     echo "---"

--- a/auth/scripts/sso-profiles-check.sh
+++ b/auth/scripts/sso-profiles-check.sh
@@ -367,27 +367,25 @@ run_validate() {
         local profile method session account_cfg role
         IFS='|' read -r profile method session account_cfg role <<< "$row"
 
-        local status account_id alias message
+        local status account_id alias
         local result
         if result=$(validate_profile "$profile"); then
             success_count=$((success_count + 1))
             status="OK"
             account_id=$(echo "$result" | cut -d'|' -f1)
             alias=$(echo "$result" | cut -d'|' -f2)
-            message="authenticated successfully"
         else
             failure_count=$((failure_count + 1))
             status="FAIL"
             account_id="${account_cfg:-<unknown>}"
             [ -z "$account_id" ] && account_id="<unknown>"
             alias="<no-alias>"
-            message="failed to authenticate"
         fi
 
         w_account=$(_col_width "$w_account" "$account_id")
         w_alias=$(_col_width "$w_alias" "$alias")
         w_profile=$(_col_width "$w_profile" "$profile")
-        display_rows+="${status}|${account_id}|${alias}|${profile}|${message}"$'\n'
+        display_rows+="${status}|${account_id}|${alias}|${profile}"$'\n'
     done < "$TMPFILE"
 
     rm -f "$TMPFILE"
@@ -395,14 +393,14 @@ run_validate() {
 
     while IFS= read -r row || [ -n "$row" ]; do
         [ -z "$row" ] && continue
-        local status account_id alias profile message
-        IFS='|' read -r status account_id alias profile message <<< "$row"
+        local status account_id alias profile
+        IFS='|' read -r status account_id alias profile <<< "$row"
         if [ "$status" = "OK" ]; then
-            printf "${GREEN}%-6s${RESET} %-*s | %-*s | %-*s - %s\n" \
-                "[OK]" "$w_account" "$account_id" "$w_alias" "$alias" "$w_profile" "$profile" "$message"
+            printf "${GREEN}%-6s${RESET} %-*s | %-*s | %-*s\n" \
+                "[OK]" "$w_account" "$account_id" "$w_alias" "$alias" "$w_profile" "$profile"
         else
-            printf "${RED}%-6s${RESET} %-*s | %-*s | %-*s - %s\n" \
-                "[FAIL]" "$w_account" "$account_id" "$w_alias" "$alias" "$w_profile" "$profile" "$message"
+            printf "${RED}%-6s${RESET} %-*s | %-*s | %-*s\n" \
+                "[FAIL]" "$w_account" "$account_id" "$w_alias" "$alias" "$w_profile" "$profile"
         fi
     done <<< "$display_rows"
 

--- a/auth/scripts/sso-profiles-check.sh
+++ b/auth/scripts/sso-profiles-check.sh
@@ -222,6 +222,21 @@ validate_profile() {
     return 0
 }
 
+_col_width() {
+    local current="$1"
+    local value="$2"
+    local len=${#value}
+    if [ "$len" -gt "$current" ]; then
+        echo "$len"
+    else
+        echo "$current"
+    fi
+}
+
+_dashes() {
+    printf '%*s' "$1" '' | tr ' ' '-'
+}
+
 run_check_config() {
     log_info "Inspecting SSO profiles in $AWS_CONFIG_FILE (no login)..."
 
@@ -241,25 +256,65 @@ run_check_config() {
     local profile_count
     profile_count=$(printf '%s\n' "$rows" | grep -c . || true)
 
+    local h_profile="PROFILE"
+    local h_method="METHOD"
+    local h_account="ACCOUNT"
+    local h_session="SESSION/ROLE"
+    local h_detail="DETAIL"
+
+    local w_profile=${#h_profile}
+    local w_method=${#h_method}
+    local w_account=${#h_account}
+    local w_session=${#h_session}
+    local w_detail=${#h_detail}
+
+    local display_rows=""
+    while IFS= read -r row || [ -n "$row" ]; do
+        [ -z "$row" ] && continue
+        local name method session account role detail col4
+        IFS='|' read -r name method session account role <<< "$row"
+        account="${account:-<unset>}"
+        if [ "$method" = "session" ]; then
+            col4="${session:-<unset>}"
+            detail="sso_session=$session"
+        else
+            col4="${role:-<unset>}"
+            detail="sso_role_name=${role:-<unset>}"
+        fi
+        w_profile=$(_col_width "$w_profile" "$name")
+        w_method=$(_col_width "$w_method" "$method")
+        w_account=$(_col_width "$w_account" "$account")
+        w_session=$(_col_width "$w_session" "$col4")
+        w_detail=$(_col_width "$w_detail" "$detail")
+        display_rows+="${name}|${method}|${account}|${col4}|${detail}"$'\n'
+    done <<< "$rows"
+
     log_ok "Found $profile_count SSO profile(s)"
     echo ""
-    printf "%-20s | %-8s | %-16s | %-14s | %s\n" "PROFILE" "METHOD" "ACCOUNT" "SESSION/ROLE" "DETAIL"
-    printf "%-20s-+-%-8s-+-%-16s-+-%-14s-+-%s\n" "--------------------" "--------" "----------------" "--------------" "------"
+    printf "%-*s | %-*s | %-*s | %-*s | %-*s\n" \
+        "$w_profile" "$h_profile" \
+        "$w_method" "$h_method" \
+        "$w_account" "$h_account" \
+        "$w_session" "$h_session" \
+        "$w_detail" "$h_detail"
+    printf "%s-+-%s-+-%s-+-%s-+-%s\n" \
+        "$(_dashes "$w_profile")" \
+        "$(_dashes "$w_method")" \
+        "$(_dashes "$w_account")" \
+        "$(_dashes "$w_session")" \
+        "$(_dashes "$w_detail")"
 
     while IFS= read -r row || [ -n "$row" ]; do
         [ -z "$row" ] && continue
-        local name method session account role detail
-        IFS='|' read -r name method session account role <<< "$row"
-        if [ "$method" = "session" ]; then
-            detail="sso_session=$session"
-            printf "%-20s | %-8s | %-16s | %-14s | %s\n" \
-                "$name" "$method" "${account:-<unset>}" "${session:-<unset>}" "$detail"
-        else
-            detail="sso_role_name=${role:-<unset>}"
-            printf "%-20s | %-8s | %-16s | %-14s | %s\n" \
-                "$name" "$method" "${account:-<unset>}" "${role:-<unset>}" "$detail"
-        fi
-    done <<< "$rows"
+        local name method account col4 detail
+        IFS='|' read -r name method account col4 detail <<< "$row"
+        printf "%-*s | %-*s | %-*s | %-*s | %-*s\n" \
+            "$w_profile" "$name" \
+            "$w_method" "$method" \
+            "$w_account" "$account" \
+            "$w_session" "$col4" \
+            "$w_detail" "$detail"
+    done <<< "$display_rows"
 
     echo ""
     echo "---"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SSO profiles check used fixed `printf` widths, so long names/aliases overflowed and misaligned columns. Validate rows also repeated success/failure in prose after `[OK]`/`[FAIL]`.

## Changes

In `auth/scripts/sso-profiles-check.sh`:

1. **`--check-config`** — measure column widths from headers + row values, then print with `%-*s` and a matching dash separator.
2. **Validate mode (no flags)** — collect STS results first, size account/alias/profile columns, pad `[OK]`/`[FAIL]` to the same width, then print aligned rows.
3. **Validate rows** — drop trailing `authenticated successfully` / `failed to authenticate`; rows are status, account, alias, profile only.

Discovery logic is unchanged. Summary counts still report success/failure.

## Test

- `--check-config` with short/long/session/legacy fixture profiles: columns align.
- Validate print path simulated with long aliases/profiles: columns align without trailing messages.
- `bash -n` OK.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1c99a06-be29-4611-8bb0-c7ea82554b95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1c99a06-be29-4611-8bb0-c7ea82554b95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

