### PR TITLE
feat(scripts): clarify SSO --check-config table columns

### DIFF
--- a/auth/scripts/sso-profiles-check.sh
+++ b/auth/scripts/sso-profiles-check.sh
@@ -259,34 +259,33 @@ run_check_config() {
     local h_profile="PROFILE"
     local h_method="METHOD"
     local h_account="ACCOUNT"
-    local h_session="SESSION/ROLE"
-    local h_detail="DETAIL"
+    local h_session="SESSION"
+    local h_role="ROLE"
 
     local w_profile=${#h_profile}
     local w_method=${#h_method}
     local w_account=${#h_account}
     local w_session=${#h_session}
-    local w_detail=${#h_detail}
+    local w_role=${#h_role}
 
     local display_rows=""
     while IFS= read -r row || [ -n "$row" ]; do
         [ -z "$row" ] && continue
-        local name method session account role detail col4
+        local name method session account role session_col role_col
         IFS='|' read -r name method session account role <<< "$row"
         account="${account:-<unset>}"
         if [ "$method" = "session" ]; then
-            col4="${session:-<unset>}"
-            detail="sso_session=$session"
+            session_col="${session:-<unset>}"
         else
-            col4="${role:-<unset>}"
-            detail="sso_role_name=${role:-<unset>}"
+            session_col="<n/a>"
         fi
+        role_col="${role:-<unset>}"
         w_profile=$(_col_width "$w_profile" "$name")
         w_method=$(_col_width "$w_method" "$method")
         w_account=$(_col_width "$w_account" "$account")
-        w_session=$(_col_width "$w_session" "$col4")
-        w_detail=$(_col_width "$w_detail" "$detail")
-        display_rows+="${name}|${method}|${account}|${col4}|${detail}"$'\n'
+        w_session=$(_col_width "$w_session" "$session_col")
+        w_role=$(_col_width "$w_role" "$role_col")
+        display_rows+="${name}|${method}|${account}|${session_col}|${role_col}"$'\n'
     done <<< "$rows"
 
     log_ok "Found $profile_count SSO profile(s)"
@@ -296,24 +295,24 @@ run_check_config() {
         "$w_method" "$h_method" \
         "$w_account" "$h_account" \
         "$w_session" "$h_session" \
-        "$w_detail" "$h_detail"
+        "$w_role" "$h_role"
     printf "%s-+-%s-+-%s-+-%s-+-%s\n" \
         "$(_dashes "$w_profile")" \
         "$(_dashes "$w_method")" \
         "$(_dashes "$w_account")" \
         "$(_dashes "$w_session")" \
-        "$(_dashes "$w_detail")"
+        "$(_dashes "$w_role")"
 
     while IFS= read -r row || [ -n "$row" ]; do
         [ -z "$row" ] && continue
-        local name method account col4 detail
-        IFS='|' read -r name method account col4 detail <<< "$row"
+        local name method account session_col role_col
+        IFS='|' read -r name method account session_col role_col <<< "$row"
         printf "%-*s | %-*s | %-*s | %-*s | %-*s\n" \
             "$w_profile" "$name" \
             "$w_method" "$method" \
             "$w_account" "$account" \
-            "$w_session" "$col4" \
-            "$w_detail" "$detail"
+            "$w_session" "$session_col" \
+            "$w_role" "$role_col"
     done <<< "$display_rows"
 
     echo ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves `--check-config` output in `sso-profiles-check.sh` by replacing the overloaded `SESSION/ROLE` + `DETAIL` columns with clear `SESSION` and `ROLE` columns.

## Changes

- **SESSION**: bare `sso_session` for session profiles; `<n/a>` for legacy
- **ROLE**: always bare `sso_role_name` (or `<unset>`)
- Drops `sso_session=` / `sso_role_name=` key prefixes

## Example

```
PROFILE  | METHOD  | ACCOUNT      | SESSION | ROLE
---------+---------+--------------+---------+--------------------
my-prod  | session | 123456789012 | my-sso  | AdministratorAccess
old-acct | legacy  | 456789012345 | <n/a>   | ReadOnlyAccess
```

## Test plan

- [x] Smoke-tested with a temp config containing one session and one legacy SSO profile
- [x] Run `./auth/scripts/sso-profiles-check.sh --check-config` against a real `~/.aws/config`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e759e5a1-32cd-4a54-b5e1-ea9ae9773ae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e759e5a1-32cd-4a54-b5e1-ea9ae9773ae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

