### PR TITLE
feat(dev-tools): migrate CodeCommit gitconfig setup script from le-git

### DIFF
--- a/dev-tools/codecommit/README.md
+++ b/dev-tools/codecommit/README.md
@@ -11,3 +11,5 @@ AWS CodeCommit is a fully-managed source control service that hosts Git reposito
 ## Related
 
 - [CLI Commands - CodeCommit](../../cli/codecommit.md)
+- [Git setup](./git-setup.md) — credentials, gitconfig helper script
+

--- a/dev-tools/codecommit/README.md
+++ b/dev-tools/codecommit/README.md
@@ -1,15 +1,23 @@
 # AWS CodeCommit
 
-AWS CodeCommit is a fully-managed source control service that hosts Git repositories.
+Notes and helpers for working with AWS CodeCommit from this repo.
+
+## Contents
+
+| Path | What it is |
+| --- | --- |
+| [git-setup.md](./git-setup.md) | Git + AWS CLI HTTPS setup: **Windows (Git Bash)** (GCM / helper script) and **Linux** (native credential-helper) |
+| [setup-cc-gitconfig.sh](./setup-cc-gitconfig.sh) | Windows Git Bash helper: check-only by default; `--fix-system` or `--migrate` when system GCM blocks CodeCommit HTTPS |
+
+> [!TIP]
+> Start with [git-setup.md](./git-setup.md). Use the script only on Windows Git Bash when Git Credential Manager intercepts CodeCommit auth.
+
+## Related
+
+- [CLI commands (CodeCommit)](../../cli/codecommit.md)
 
 ## References
 
 - [What is AWS CodeCommit?](https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html)
-- [AWS CLI Reference - AWS CodeCommit](https://docs.aws.amazon.com/cli/latest/reference/codecommit/)
+- [AWS CLI reference: CodeCommit](https://docs.aws.amazon.com/cli/latest/reference/codecommit/)
 - [AWS managed policies for CodeCommit](https://docs.aws.amazon.com/codecommit/latest/userguide/security-iam-awsmanpol.html)
-
-## Related
-
-- [CLI Commands - CodeCommit](../../cli/codecommit.md)
-- [Git setup](./git-setup.md) — credentials, gitconfig helper script
-

--- a/dev-tools/codecommit/git-setup.md
+++ b/dev-tools/codecommit/git-setup.md
@@ -1,22 +1,33 @@
 # AWS CodeCommit
 
-## Working with AWS CodeCommit
+## Prerequisites
 
-### Prerequisites
+- Git configured with a usable `~/.gitconfig`
+- AWS CLI v2 (the CodeCommit credential helper ships with CLI v2 only)
+- An IAM role or user with `AWSCodeCommitReadOnly` or `AWSCodeCommitPowerUser`
 
-- Git - Git with the `.gitconfig` properly configured
-- AWS CLI v2 - AWS CodeCommit has a native helper that only works with AWS CLI version 2
-- AWS IAM Role - IAM role that contains `AWSCodeCommitReadOnly` or `AWSCodeCommitPowerUser`
+Preferred stack: Git + AWS CLI v2 + HTTPS remotes using `aws codecommit credential-helper`. Console **HTTPS (GRC)** / [`git-remote-codecommit`](https://github.com/aws/git-remote-codecommit) adds a Python dependency, has seen little upstream activity since ~2023, and is unnecessary when git and AWS CLI v2 already speak CodeCommit HTTPS.
 
-### Git Config
+## Windows (Git Bash)
 
-For Git Bash setups where Git Credential Manager (GCM) intercepts CodeCommit HTTPS
-auth, use [`./setup-cc-gitconfig.sh`](./setup-cc-gitconfig.sh). The default run is
-**check-only** (mutates nothing). Mutating modes (`--fix-system`, `--migrate`)
-back up to `~/gitconfig-backups/` before writing.
+Corporate Git for Windows often sets system `credential.helper = manager` (Git Credential Manager). GCM then pops a username/password dialog and blocks CodeCommit HTTPS auth, which expects the AWS CLI credential helper instead.
+
+### Helper script
+
+[`./setup-cc-gitconfig.sh`](./setup-cc-gitconfig.sh) prepares Git Bash so the AWS CLI helper can run without that GCM dialog.
+
+| Mode | Behavior |
+| --- | --- |
+| Default (check-only) | Reports system/global/effective `credential.helper`, whether the system gitconfig is writable, and whether `GIT_CONFIG_NOSYSTEM` is set. |
+| `--fix-system` | If the system gitconfig is writable, unsets the system `credential.helper`. |
+| `--migrate` | If the system gitconfig is read-only: merges system settings into the existing global config (skips GCM helpers), appends `export GIT_CONFIG_NOSYSTEM=1` to an existing `~/.bashrc`, then reload the shell. Requires `~/.gitconfig` and `~/.bashrc` (does not create them). |
+
+Mutating modes back up to `~/gitconfig-backups/` (override with `--backup-dir`) before writing.
+
+Exit codes: `0` success (no effective manager helper, or `--migrate` succeeded); `1` manager still active; `2` usage error, missing prereqs, or unexpected failure.
 
 ```shell
-# check only (default — mutates nothing)
+# check only (default)
 ./setup-cc-gitconfig.sh
 
 # writable system gitconfig: remove system credential.helper (GCM)
@@ -26,15 +37,9 @@ back up to `~/gitconfig-backups/` before writing.
 ./setup-cc-gitconfig.sh --migrate
 ```
 
-**Preferred stack:** Git + AWS CLI v2 + HTTPS remotes with
-`aws codecommit credential-helper` — not console **HTTPS (GRC)** /
-[`git-remote-codecommit`](https://github.com/aws/git-remote-codecommit)
-(extra Python dependency; little upstream activity since ~2023; unnecessary when
-git + AWS CLI v2 already support CodeCommit HTTPS).
+### Manual alternative (URL-scoped helpers)
 
-URL-scoped credential helper (set as part of normal AWS/Git setup; the script
-does not write these for you). Git Bash: use **single quotes** with `git config`
-per the AWS Windows HTTPS docs.
+The script does not write URL-scoped helpers for you. Add them to `~/.gitconfig` as AWS docs recommend. In Git Bash, use **single quotes** with `git config`.
 
 ```ini
 [credential "https://git-codecommit.us-east-1.amazonaws.com"]
@@ -59,15 +64,50 @@ git config --global credential.https://git-codecommit.*.amazonaws.com.helper '!a
 git config --global credential.UseHttpPath true
 ```
 
-### AWS CodeCommit Helper - Git Remote CodeCommit
+## Linux
 
-- https://github.com/aws/git-remote-codecommit
-- https://pypi.org/project/git-remote-codecommit/
+No GCM in the way on a typical Linux install, so the Windows helper script is not needed. Point Git at the AWS CLI v2 credential helper with the same URL-scoped pattern.
+
+### Credential helper
+
+```ini
+[credential "https://git-codecommit.us-east-1.amazonaws.com"]
+        helper = !aws codecommit credential-helper $@
+        UseHttpPath = true
+
+[credential "https://git-codecommit.us-east-2.amazonaws.com"]
+        helper = !aws codecommit credential-helper $@
+        UseHttpPath = true
+```
+
+Wildcard variant:
+
+```ini
+[credential "https://git-codecommit.*.amazonaws.com"]
+        helper = !aws codecommit credential-helper $@
+        UseHttpPath = true
+```
+
+```shell
+git config --global credential.https://git-codecommit.*.amazonaws.com.helper '!aws codecommit credential-helper $@'
+git config --global credential.UseHttpPath true
+```
+
+### AWS CLI and IAM
+
+Install AWS CLI v2, set a default region (`aws configure` or environment), and make sure the process can resolve credentials (shared config/credentials, instance/profile role, or `credential_source` where you already use that pattern). The principal needs CodeCommit read or power-user access as listed under [Prerequisites](#prerequisites).
+
+HTTPS with the AWS CLI credential helper is enough for day-to-day clone/push. You do not need HTTPS(GRC) or `git-remote-codecommit` when that helper is configured.
+
+SSH to CodeCommit is another option on Linux; see [Setup for SSH users](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-ssh-unixes.html).
 
 ## References
 
 - [Setup for HTTPS users using Git credentials](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-gc.html)
-- [Setup steps for HTTPS connections to AWS CodeCommit with git-remote-codecommit](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-git-remote-codecommit.html)
 - [Setup steps for HTTPS connections to AWS CodeCommit repositories on Windows with the AWS CLI credential helper](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-https-windows.html)
+- [Setup steps for HTTPS connections to AWS CodeCommit with git-remote-codecommit](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-git-remote-codecommit.html)
+- [Setup for SSH users on Linux, macOS, or Unix](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-ssh-unixes.html)
 - [Troubleshooting the credential helper and HTTPS connections to AWS CodeCommit](https://docs.aws.amazon.com/codecommit/latest/userguide/troubleshooting-ch.html)
 - [Troubleshooting Git credentials and HTTPS connections to AWS CodeCommit](https://docs.aws.amazon.com/codecommit/latest/userguide/troubleshooting-gc.html)
+- [git-remote-codecommit (GitHub)](https://github.com/aws/git-remote-codecommit)
+- [git-remote-codecommit (PyPI)](https://pypi.org/project/git-remote-codecommit/)

--- a/dev-tools/codecommit/git-setup.md
+++ b/dev-tools/codecommit/git-setup.md
@@ -10,8 +10,53 @@
 
 ### Git Config
 
-```shell
+For Git Bash setups where Git Credential Manager (GCM) intercepts CodeCommit HTTPS
+auth, use [`./setup-cc-gitconfig.sh`](./setup-cc-gitconfig.sh). The default run is
+**check-only** (mutates nothing). Mutating modes (`--fix-system`, `--migrate`)
+back up to `~/gitconfig-backups/` before writing.
 
+```shell
+# check only (default — mutates nothing)
+./setup-cc-gitconfig.sh
+
+# writable system gitconfig: remove system credential.helper (GCM)
+./setup-cc-gitconfig.sh --fix-system
+
+# read-only system gitconfig: merge into global + GIT_CONFIG_NOSYSTEM
+./setup-cc-gitconfig.sh --migrate
+```
+
+**Preferred stack:** Git + AWS CLI v2 + HTTPS remotes with
+`aws codecommit credential-helper` — not console **HTTPS (GRC)** /
+[`git-remote-codecommit`](https://github.com/aws/git-remote-codecommit)
+(extra Python dependency; little upstream activity since ~2023; unnecessary when
+git + AWS CLI v2 already support CodeCommit HTTPS).
+
+URL-scoped credential helper (set as part of normal AWS/Git setup; the script
+does not write these for you). Git Bash: use **single quotes** with `git config`
+per the AWS Windows HTTPS docs.
+
+```ini
+[credential "https://git-codecommit.us-east-1.amazonaws.com"]
+        helper = !aws codecommit credential-helper $@
+        UseHttpPath = true
+
+[credential "https://git-codecommit.us-east-2.amazonaws.com"]
+        helper = !aws codecommit credential-helper $@
+        UseHttpPath = true
+```
+
+Or a wildcard covering CodeCommit hosts:
+
+```ini
+[credential "https://git-codecommit.*.amazonaws.com"]
+        helper = !aws codecommit credential-helper $@
+        UseHttpPath = true
+```
+
+```shell
+git config --global credential.https://git-codecommit.*.amazonaws.com.helper '!aws codecommit credential-helper $@'
+git config --global credential.UseHttpPath true
 ```
 
 ### AWS CodeCommit Helper - Git Remote CodeCommit

--- a/dev-tools/codecommit/git-setup.md
+++ b/dev-tools/codecommit/git-setup.md
@@ -19,8 +19,8 @@ Corporate Git for Windows often sets system `credential.helper = manager` (Git C
 | Mode | Behavior |
 | --- | --- |
 | Default (check-only) | Reports system/global/effective `credential.helper`, whether the system gitconfig is writable, and whether `GIT_CONFIG_NOSYSTEM` is set. |
-| `--fix-system` | If the system gitconfig is writable, unsets the system `credential.helper`. |
-| `--migrate` | If the system gitconfig is read-only: merges system settings into the existing global config (skips GCM helpers), appends `export GIT_CONFIG_NOSYSTEM=1` to an existing `~/.bashrc`, then reload the shell. Requires `~/.gitconfig` and `~/.bashrc` (does not create them). |
+| `--fix-system` | If the system gitconfig is writable, removes GCM (manager) helper values from the system `credential.helper`, preserving other helpers. |
+| `--migrate` | If the system gitconfig is read-only: merges system settings into the existing global config (skips GCM helpers), appends `export GIT_CONFIG_NOSYSTEM=1` to an existing `~/.bashrc`; reload the shell afterwards to apply it. Requires `~/.gitconfig` and `~/.bashrc` (does not create them). |
 
 Mutating modes back up to `~/gitconfig-backups/` (override with `--backup-dir`) before writing.
 
@@ -30,7 +30,7 @@ Exit codes: `0` success (no effective manager helper, or `--migrate` succeeded);
 # check only (default)
 ./setup-cc-gitconfig.sh
 
-# writable system gitconfig: remove system credential.helper (GCM)
+# writable system gitconfig: remove GCM helpers only (preserve others)
 ./setup-cc-gitconfig.sh --fix-system
 
 # read-only system gitconfig: merge into global + GIT_CONFIG_NOSYSTEM

--- a/dev-tools/codecommit/setup-cc-gitconfig.sh
+++ b/dev-tools/codecommit/setup-cc-gitconfig.sh
@@ -1,0 +1,444 @@
+#!/usr/bin/env bash
+# Setup Git config for AWS CodeCommit HTTPS (Git Bash / Windows).
+# Clears system credential.helper=manager so AWS CLI credential-helper can auth
+# without a username/password dialog. Prefer --fix-system or --migrate + bashrc NOSYSTEM.
+
+set -euo pipefail
+
+BACKUP_DIR="${HOME}/gitconfig-backups"
+DO_FIX_SYSTEM=0
+DO_MIGRATE=0
+PROBE_KEY="setup.cc.gitconfig.probe"
+BASHRC_MARKER="# managed-by: setup-cc-gitconfig.sh"
+GLOBAL_GITCONFIG="${HOME}/.gitconfig"
+USER_BASHRC="${HOME}/.bashrc"
+
+print_help() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Prepare Git for CodeCommit HTTPS with AWS CLI credential-helper
+(no GCM username/password dialog). Default is check-only.
+Mutating flags back up configs first.
+
+Options:
+  --fix-system       Unset credential.helper in system gitconfig (if writable)
+  --migrate          Merge system settings into existing global (skip GCM),
+                     append GIT_CONFIG_NOSYSTEM=1 to existing ~/.bashrc
+                     Requires ~/.gitconfig and ~/.bashrc (does not create them)
+  --backup-dir DIR   Backup directory (default: ~/gitconfig-backups)
+  -h, --help         Show this help and exit
+
+Exit codes:
+  0  No effective manager/manager-core helper, or --migrate succeeded
+  1  Effective manager still active (see Recommendation)
+  2  Usage error, missing prereqs, git missing, or unexpected failure
+
+Policy:
+  1) Writable system  -> unset system credential.helper (--fix-system)
+  2) Read-only system -> --migrate (merge system->global, enable NOSYSTEM in ~/.bashrc)
+EOF
+}
+
+log() { printf '%s\n' "$*"; }
+warn() { printf 'WARN: %s\n' "$*" >&2; }
+err() { printf 'ERROR: %s\n' "$*" >&2; }
+
+is_gcm_helper() {
+  local val="$1"
+  case "$val" in
+    manager|manager-core|manager-core.exe|git-credential-manager|git-credential-manager.exe|git-credential-manager-core|git-credential-manager-core.exe)
+      return 0
+      ;;
+    *git-credential-manager*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# Apply credential.helper empty-reset semantics (get-all does not).
+effective_helpers() {
+  local helper
+  local -a helpers=()
+  while IFS= read -r helper; do
+    if [[ "$helper" == "" ]]; then
+      helpers=()
+      continue
+    fi
+    helpers+=("$helper")
+  done < <(git config --get-all credential.helper 2>/dev/null || true)
+
+  if ((${#helpers[@]} > 0)); then
+    printf '%s\n' "${helpers[@]}"
+  fi
+}
+
+effective_has_manager() {
+  local helper
+  while IFS= read -r helper; do
+    [[ -z "$helper" ]] && continue
+    if is_gcm_helper "$helper"; then
+      return 0
+    fi
+  done < <(effective_helpers)
+  return 1
+}
+
+system_config_path() {
+  local origin path
+  # Prefer an explicit list entry: file:<path><tab>key=value
+  origin="$(git config --system --list --show-origin 2>/dev/null | head -n1 || true)"
+  if [[ -n "$origin" ]]; then
+    path="$(printf '%s\n' "$origin" | sed -E 's/^file:([^[:space:]]+).*/\1/')"
+    if [[ -n "$path" ]]; then
+      printf '%s\n' "$path"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+can_write_system() {
+  if git config --system --add "$PROBE_KEY" 1 2>/dev/null; then
+    git config --system --unset-all "$PROBE_KEY" 2>/dev/null || true
+    return 0
+  fi
+  git config --system --unset-all "$PROBE_KEY" 2>/dev/null || true
+  return 1
+}
+
+backup_file() {
+  local src="$1"
+  local label="$2"
+  local stamp dest
+  [[ -f "$src" ]] || return 0
+  mkdir -p "$BACKUP_DIR"
+  stamp="$(date +%Y%m%d-%H%M%S)"
+  dest="${BACKUP_DIR}/gitconfig.${label}.${stamp}.bak"
+  cp -v "$src" "$dest"
+}
+
+backup_configs() {
+  local sys_path global_path
+  sys_path="$(system_config_path 2>/dev/null || true)"
+  global_path="$(git config --global --list --show-origin 2>/dev/null | head -n1 | sed -E 's/^file:([^[:space:]]+).*/\1/' || true)"
+  if [[ -z "$global_path" && -f "${HOME}/.gitconfig" ]]; then
+    global_path="${HOME}/.gitconfig"
+  fi
+  if [[ -n "$sys_path" ]]; then
+    backup_file "$sys_path" "system"
+  fi
+  if [[ -n "$global_path" ]]; then
+    backup_file "$global_path" "global"
+  fi
+}
+
+print_section() {
+  log ""
+  log "== $* =="
+}
+
+print_credential_section() {
+  local scope="$1"
+  print_section "${scope} credential.*"
+  if ! git config --"${scope}" --get-regexp '^credential\.' 2>/dev/null; then
+    log "(none or unreadable)"
+  fi
+}
+
+windows_user_nosystem() {
+  # Returns User env value, or empty if unset / not Windows.
+  local val
+  if ! command -v cmd.exe >/dev/null 2>&1; then
+    return 1
+  fi
+  val="$(cmd.exe //c "if defined GIT_CONFIG_NOSYSTEM (echo %GIT_CONFIG_NOSYSTEM%) else (echo __UNSET__)" 2>/dev/null | tr -d '\r' | tail -n1)"
+  if [[ -z "$val" || "$val" == "__UNSET__" || "$val" == "%GIT_CONFIG_NOSYSTEM%" ]]; then
+    return 1
+  fi
+  printf '%s\n' "$val"
+  return 0
+}
+
+print_nosystem_status() {
+  print_section "GIT_CONFIG_NOSYSTEM status"
+  log "shell GIT_CONFIG_NOSYSTEM=${GIT_CONFIG_NOSYSTEM-<unset>}"
+  log "shell GIT_CONFIG_SYSTEM=${GIT_CONFIG_SYSTEM-<unset>}"
+
+  local user_val
+  if user_val="$(windows_user_nosystem)"; then
+    log "Windows User env GIT_CONFIG_NOSYSTEM=${user_val}"
+    if [[ -n "${GIT_CONFIG_NOSYSTEM:-}" && "${GIT_CONFIG_NOSYSTEM}" != "${user_val}" ]]; then
+      warn "Shell and Windows User GIT_CONFIG_NOSYSTEM differ"
+    fi
+  else
+    if command -v cmd.exe >/dev/null 2>&1; then
+      log "Windows User env GIT_CONFIG_NOSYSTEM=<unset>"
+      if [[ -n "${GIT_CONFIG_NOSYSTEM:-}" ]]; then
+        warn "GIT_CONFIG_NOSYSTEM is set in this shell (e.g. ~/.bashrc) but not as a Windows User env var"
+      fi
+    else
+      log "Windows User env check skipped (cmd.exe not available)"
+    fi
+  fi
+}
+
+fix_system_helpers() {
+  print_section "Fixing system credential.helper"
+  if ! can_write_system; then
+    err "No write permission on system gitconfig; use --migrate instead"
+    return 1
+  fi
+  if git config --system --get-all credential.helper >/dev/null 2>&1; then
+    git config --system --unset-all credential.helper
+    log "Unset system credential.helper"
+  else
+    log "System credential.helper already absent"
+  fi
+}
+
+is_skipped_migrate_key() {
+  local key="$1"
+  local val="$2"
+  if [[ "$key" == "$PROBE_KEY" ]]; then
+    return 0
+  fi
+  if [[ "$key" == "credential.helper" ]] && is_gcm_helper "$val"; then
+    return 0
+  fi
+  return 1
+}
+
+require_migrate_prereqs() {
+  local missing=0
+  if [[ ! -f "$GLOBAL_GITCONFIG" ]]; then
+    err "Global gitconfig not found: ${GLOBAL_GITCONFIG}"
+    warn "Create ~/.gitconfig first, then re-run --migrate"
+    missing=1
+  fi
+  if [[ ! -f "$USER_BASHRC" ]]; then
+    err "bashrc not found: ${USER_BASHRC}"
+    warn "Create ~/.bashrc first, then re-run --migrate"
+    missing=1
+  fi
+  if [[ "$missing" -ne 0 ]]; then
+    return 1
+  fi
+  return 0
+}
+
+bashrc_has_nosystem() {
+  grep -Eq '^[[:space:]]*export[[:space:]]+GIT_CONFIG_NOSYSTEM=' "$USER_BASHRC" 2>/dev/null \
+    || grep -Eq '^[[:space:]]*GIT_CONFIG_NOSYSTEM=' "$USER_BASHRC" 2>/dev/null
+}
+
+append_nosystem_to_bashrc() {
+  print_section "Persist GIT_CONFIG_NOSYSTEM in ~/.bashrc"
+  if bashrc_has_nosystem; then
+    log "GIT_CONFIG_NOSYSTEM already present in ${USER_BASHRC}"
+  else
+    {
+      printf '\n%s\n' "$BASHRC_MARKER"
+      printf 'export GIT_CONFIG_NOSYSTEM=1\n'
+    } >> "$USER_BASHRC"
+    log "Added GIT_CONFIG_NOSYSTEM=1 to ${USER_BASHRC}"
+  fi
+
+  log ""
+  log "Reload your shell, then re-run this script:"
+  log "  source ~/.bashrc"
+  log "  # or close/reopen Git Bash"
+}
+
+migrate_system_to_global() {
+  local key val count skipped
+  print_section "Migrating system -> global"
+  count=0
+  skipped=0
+
+  if ! git config --system --list >/dev/null 2>&1; then
+    err "Unable to read system gitconfig"
+    return 1
+  fi
+
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    key="${line%%=*}"
+    val="${line#*=}"
+
+    if is_skipped_migrate_key "$key" "$val"; then
+      log "skip: ${key}=${val}"
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    if git config --global --get-all "$key" 2>/dev/null | grep -Fxq -- "$val" || false; then
+      continue
+    fi
+
+    git config --global --add "$key" "$val"
+    log "add:  ${key}=${val}"
+    count=$((count + 1))
+  done < <(git config --system --list)
+
+  log "Migrated ${count} value(s); skipped ${skipped} GCM/probe value(s)"
+  log "Global settings preserved (merge-only; nothing deleted)"
+
+  append_nosystem_to_bashrc
+}
+
+recommend_action() {
+  local writable="$1"
+  print_section "Recommendation"
+  if effective_has_manager; then
+    if [[ "$writable" == "yes" ]]; then
+      log "System gitconfig is writable."
+      log "Run: $0 --fix-system"
+    else
+      log "System gitconfig is read-only."
+      log "Run: $0 --migrate"
+      log "This merges system settings into ~/.gitconfig and enables GIT_CONFIG_NOSYSTEM in ~/.bashrc."
+    fi
+  else
+    log "No effective GCM manager helper detected."
+    if [[ -n "${GIT_CONFIG_NOSYSTEM:-}" ]]; then
+      warn "OK depends on GIT_CONFIG_NOSYSTEM (system config ignored)"
+    fi
+  fi
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        print_help
+        exit 0
+        ;;
+      --fix-system)
+        DO_FIX_SYSTEM=1
+        shift
+        ;;
+      --migrate)
+        DO_MIGRATE=1
+        shift
+        ;;
+      --backup-dir)
+        if [[ $# -lt 2 ]]; then
+          err "--backup-dir requires a directory"
+          exit 2
+        fi
+        BACKUP_DIR="$2"
+        shift 2
+        ;;
+      *)
+        err "Unknown option: $1"
+        print_help
+        exit 2
+        ;;
+    esac
+  done
+
+  if [[ "$DO_FIX_SYSTEM" -eq 1 && "$DO_MIGRATE" -eq 1 ]]; then
+    err "Use either --fix-system or --migrate, not both"
+    exit 2
+  fi
+}
+
+main() {
+  parse_args "$@"
+
+  if ! command -v git >/dev/null 2>&1; then
+    err "git is not installed or not on PATH"
+    exit 2
+  fi
+
+  log "Git config credential check"
+  log "git: $(git --version)"
+
+  local sys_path writable
+  sys_path="$(system_config_path 2>/dev/null || true)"
+  if [[ -n "$sys_path" ]]; then
+    log "system gitconfig: ${sys_path}"
+  else
+    warn "Could not resolve system gitconfig path"
+  fi
+
+  if can_write_system; then
+    writable="yes"
+    log "system write permission: yes"
+  else
+    writable="no"
+    log "system write permission: no"
+  fi
+
+  if [[ "$DO_MIGRATE" -eq 1 ]]; then
+    require_migrate_prereqs || exit 2
+  fi
+
+  if [[ "$DO_FIX_SYSTEM" -eq 1 || "$DO_MIGRATE" -eq 1 ]]; then
+    print_section "Backup"
+    backup_configs
+  fi
+
+  if [[ "$DO_FIX_SYSTEM" -eq 1 ]]; then
+    fix_system_helpers || exit 2
+  fi
+
+  if [[ "$DO_MIGRATE" -eq 1 ]]; then
+    migrate_system_to_global || exit 2
+  fi
+
+  print_credential_section system
+  print_credential_section global
+
+  print_section "Effective credential.helper (after empty-reset rules)"
+  local eff
+  eff="$(effective_helpers)"
+  if [[ -n "$eff" ]]; then
+    printf '%s\n' "$eff"
+  else
+    log "(none)"
+  fi
+  log ""
+  log "-- raw values with origins (before empty-reset rules) --"
+  git config --list --show-origin 2>/dev/null | grep -i credential.helper || log "(none)"
+
+  print_section "Effective system gitconfig origins"
+  if [[ -n "$sys_path" ]] && git config --list --show-origin 2>/dev/null | grep -Fq "file:${sys_path}"; then
+    log "SYSTEM CONFIG IS ACTIVE in effective config"
+    git config --list --show-origin 2>/dev/null | grep -F "file:${sys_path}" || true
+  elif git config --list --show-origin 2>/dev/null | grep -q 'etc/gitconfig'; then
+    log "SYSTEM CONFIG IS ACTIVE in effective config"
+    git config --list --show-origin 2>/dev/null | grep 'etc/gitconfig' || true
+  else
+    log "System gitconfig not present in effective config"
+  fi
+
+  print_nosystem_status
+  recommend_action "$writable"
+
+  # --migrate succeeds even if this session still sees system manager (reload required).
+  if [[ "$DO_MIGRATE" -eq 1 ]]; then
+    print_section "Result"
+    log "OK: migrate complete; reload shell for GIT_CONFIG_NOSYSTEM to take effect"
+    exit 0
+  fi
+
+  if effective_has_manager; then
+    print_section "Result"
+    log "FAIL: credential.helper manager is still effective"
+    log "See Recommendation above (--fix-system or --migrate)."
+    exit 1
+  fi
+
+  if [[ -n "${GIT_CONFIG_NOSYSTEM:-}" ]]; then
+    warn "Passing with GIT_CONFIG_NOSYSTEM set (system config ignored)"
+  fi
+
+  print_section "Result"
+  log "OK: no effective credential.helper manager"
+  exit 0
+}
+
+main "$@"

--- a/dev-tools/codecommit/setup-cc-gitconfig.sh
+++ b/dev-tools/codecommit/setup-cc-gitconfig.sh
@@ -8,7 +8,6 @@ set -euo pipefail
 BACKUP_DIR="${HOME}/gitconfig-backups"
 DO_FIX_SYSTEM=0
 DO_MIGRATE=0
-PROBE_KEY="setup.cc.gitconfig.probe"
 BASHRC_MARKER="# managed-by: setup-cc-gitconfig.sh"
 GLOBAL_GITCONFIG="${HOME}/.gitconfig"
 USER_BASHRC="${HOME}/.bashrc"
@@ -22,7 +21,8 @@ Prepare Git for CodeCommit HTTPS with AWS CLI credential-helper
 Mutating flags back up configs first.
 
 Options:
-  --fix-system       Unset credential.helper in system gitconfig (if writable)
+  --fix-system       Remove GCM (manager) helper values from the system
+                     credential.helper, preserving other helpers (if writable)
   --migrate          Merge system settings into existing global (skip GCM),
                      append GIT_CONFIG_NOSYSTEM=1 to existing ~/.bashrc
                      Requires ~/.gitconfig and ~/.bashrc (does not create them)
@@ -35,7 +35,7 @@ Exit codes:
   2  Usage error, missing prereqs, git missing, or unexpected failure
 
 Policy:
-  1) Writable system  -> unset system credential.helper (--fix-system)
+  1) Writable system  -> remove GCM helpers from system credential.helper (--fix-system)
   2) Read-only system -> --migrate (merge system->global, enable NOSYSTEM in ~/.bashrc)
 EOF
 }
@@ -43,6 +43,8 @@ EOF
 log() { printf '%s\n' "$*"; }
 warn() { printf 'WARN: %s\n' "$*" >&2; }
 err() { printf 'ERROR: %s\n' "$*" >&2; }
+
+trap 'err "Unexpected failure on line $LINENO"; exit 2' ERR
 
 is_gcm_helper() {
   local val="$1"
@@ -86,25 +88,42 @@ effective_has_manager() {
 }
 
 system_config_path() {
-  local origin path
-  # Prefer an explicit list entry: file:<path><tab>key=value
-  origin="$(git config --system --list --show-origin 2>/dev/null | head -n1 || true)"
-  if [[ -n "$origin" ]]; then
-    path="$(printf '%s\n' "$origin" | sed -E 's/^file:([^[:space:]]+).*/\1/')"
-    if [[ -n "$path" ]]; then
-      printf '%s\n' "$path"
-      return 0
-    fi
-  fi
-  return 1
+  # Prefer an explicit list entry: file:<path><TAB>key=value (paths may contain spaces)
+  local line path
+  line="$(git config --system --list --show-origin 2>/dev/null | head -n1 || true)"
+  [[ -n "$line" ]] || return 1
+  path="${line#file:}"
+  path="${path%%$'\t'*}"
+  [[ -n "$path" ]] || return 1
+  printf '%s\n' "$path"
+  return 0
 }
 
+# Read-only writability check (no probe writes to system gitconfig).
 can_write_system() {
-  if git config --system --add "$PROBE_KEY" 1 2>/dev/null; then
-    git config --system --unset-all "$PROBE_KEY" 2>/dev/null || true
+  local path dir parent
+  path="$(system_config_path 2>/dev/null || true)"
+  if [[ -z "$path" ]]; then
+    return 1
+  fi
+  if [[ -f "$path" ]]; then
+    if [[ -w "$path" ]]; then
+      return 0
+    fi
+    return 1
+  fi
+  # File does not exist: git would create it; check nearest existing ancestor dir.
+  dir="$(dirname -- "$path")"
+  while [[ ! -d "$dir" ]]; do
+    parent="$(dirname -- "$dir")"
+    if [[ "$parent" == "$dir" ]]; then
+      return 1
+    fi
+    dir="$parent"
+  done
+  if [[ -w "$dir" ]]; then
     return 0
   fi
-  git config --system --unset-all "$PROBE_KEY" 2>/dev/null || true
   return 1
 }
 
@@ -119,19 +138,38 @@ backup_file() {
   cp -v "$src" "$dest"
 }
 
+# Parse file:<path><TAB>... origin lines; print distinct existing paths (tab-safe for spaces).
+collect_origin_paths() {
+  local line path
+  local -A seen=()
+  while IFS= read -r line; do
+    [[ -z "$line" || "$line" != file:* ]] && continue
+    path="${line#file:}"
+    path="${path%%$'\t'*}"
+    [[ -n "$path" ]] || continue
+    [[ -n "${seen[$path]+x}" ]] && continue
+    seen[$path]=1
+    printf '%s\n' "$path"
+  done
+}
+
 backup_configs() {
-  local sys_path global_path
-  sys_path="$(system_config_path 2>/dev/null || true)"
-  global_path="$(git config --global --list --show-origin 2>/dev/null | head -n1 | sed -E 's/^file:([^[:space:]]+).*/\1/' || true)"
-  if [[ -z "$global_path" && -f "${HOME}/.gitconfig" ]]; then
-    global_path="${HOME}/.gitconfig"
-  fi
-  if [[ -n "$sys_path" ]]; then
-    backup_file "$sys_path" "system"
-  fi
-  if [[ -n "$global_path" ]]; then
-    backup_file "$global_path" "global"
-  fi
+  local path
+  local -A seen=()
+
+  while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+    [[ -n "${seen[$path]+x}" ]] && continue
+    seen[$path]=1
+    backup_file "$path" "system"
+  done < <(git config --system --list --show-origin 2>/dev/null | collect_origin_paths || true)
+
+  while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+    [[ -n "${seen[$path]+x}" ]] && continue
+    seen[$path]=1
+    backup_file "$path" "global"
+  done < <(git config --global --list --show-origin 2>/dev/null | collect_origin_paths || true)
 }
 
 print_section() {
@@ -184,26 +222,44 @@ print_nosystem_status() {
   fi
 }
 
+# Escape a string for use as an anchored ERE value-regex with git config --unset-all.
+escape_config_regex() {
+  printf '%s' "$1" | sed -E 's/[][\\.*^$+?{}|()]/\\&/g'
+}
+
+# Remove GCM (manager) helper values from the system credential.helper, preserving other helpers.
 fix_system_helpers() {
   print_section "Fixing system credential.helper"
   if ! can_write_system; then
     err "No write permission on system gitconfig; use --migrate instead"
     return 1
   fi
-  if git config --system --get-all credential.helper >/dev/null 2>&1; then
-    git config --system --unset-all credential.helper
-    log "Unset system credential.helper"
+
+  local helper escaped
+  local removed=0
+  local -A seen=()
+
+  while IFS= read -r helper; do
+    [[ -z "$helper" ]] && continue
+    [[ -n "${seen[$helper]+x}" ]] && continue
+    seen[$helper]=1
+    if is_gcm_helper "$helper"; then
+      escaped="$(escape_config_regex "$helper")"
+      git config --system --unset-all credential.helper "^${escaped}$"
+      removed=$((removed + 1))
+    fi
+  done < <(git config --system --get-all credential.helper 2>/dev/null || true)
+
+  if [[ "$removed" -gt 0 ]]; then
+    log "GCM helper(s) removed from system credential.helper"
   else
-    log "System credential.helper already absent"
+    log "no GCM helper present"
   fi
 }
 
 is_skipped_migrate_key() {
   local key="$1"
   local val="$2"
-  if [[ "$key" == "$PROBE_KEY" ]]; then
-    return 0
-  fi
   if [[ "$key" == "credential.helper" ]] && is_gcm_helper "$val"; then
     return 0
   fi
@@ -282,7 +338,7 @@ migrate_system_to_global() {
     count=$((count + 1))
   done < <(git config --system --list)
 
-  log "Migrated ${count} value(s); skipped ${skipped} GCM/probe value(s)"
+  log "Migrated ${count} value(s); skipped ${skipped} GCM value(s)"
   log "Global settings preserved (merge-only; nothing deleted)"
 
   append_nosystem_to_bashrc

--- a/dev-tools/codecommit/setup-cc-gitconfig.sh
+++ b/dev-tools/codecommit/setup-cc-gitconfig.sh
@@ -3,7 +3,7 @@
 # Clears system credential.helper=manager so AWS CLI credential-helper can auth
 # without a username/password dialog. Prefer --fix-system or --migrate + bashrc NOSYSTEM.
 
-set -euo pipefail
+set -eEuo pipefail
 
 BACKUP_DIR="${HOME}/gitconfig-backups"
 DO_FIX_SYSTEM=0
@@ -130,11 +130,14 @@ can_write_system() {
 backup_file() {
   local src="$1"
   local label="$2"
-  local stamp dest
+  local stamp dest base
   [[ -f "$src" ]] || return 0
   mkdir -p "$BACKUP_DIR"
   stamp="$(date +%Y%m%d-%H%M%S)"
-  dest="${BACKUP_DIR}/gitconfig.${label}.${stamp}.bak"
+  base="$(basename -- "$src")"
+  base="${base#.}" # e.g. .gitconfig -> gitconfig (avoid "..")
+  # Basename disambiguates multiple origins under the same scope (e.g. [include] targets).
+  dest="${BACKUP_DIR}/gitconfig.${label}.${base}.${stamp}.bak"
   cp -v "$src" "$dest"
 }
 
@@ -153,23 +156,54 @@ collect_origin_paths() {
   done
 }
 
+# Warn when a GCM helper value lives in an [include] target (not the primary file).
+warn_gcm_in_included() {
+  local scope="$1"
+  local primary="$2"
+  local line path rest key val
+
+  [[ -n "$primary" ]] || return 0
+
+  while IFS= read -r line; do
+    [[ -z "$line" || "$line" != file:* ]] && continue
+    path="${line#file:}"
+    path="${path%%$'\t'*}"
+    rest="${line#*$'\t'}"
+    [[ "$rest" == *=* ]] || continue
+    key="${rest%%=*}"
+    val="${rest#*=}"
+    [[ "$key" == "credential.helper" ]] || continue
+    is_gcm_helper "$val" || continue
+    if [[ "$path" != "$primary" ]]; then
+      warn "GCM credential.helper (${val}) lives in included ${scope} file: ${path}"
+    fi
+  done < <(git config --"${scope}" --list --show-origin --includes 2>/dev/null || true)
+}
+
 backup_configs() {
-  local path
+  local path primary
   local -A seen=()
 
+  primary="$(system_config_path 2>/dev/null || true)"
   while IFS= read -r path; do
     [[ -z "$path" ]] && continue
     [[ -n "${seen[$path]+x}" ]] && continue
     seen[$path]=1
     backup_file "$path" "system"
-  done < <(git config --system --list --show-origin 2>/dev/null | collect_origin_paths || true)
+  done < <(git config --system --list --show-origin --includes 2>/dev/null | collect_origin_paths || true)
+  warn_gcm_in_included system "$primary"
 
+  primary=""
+  if [[ -f "$GLOBAL_GITCONFIG" ]]; then
+    primary="$GLOBAL_GITCONFIG"
+  fi
   while IFS= read -r path; do
     [[ -z "$path" ]] && continue
     [[ -n "${seen[$path]+x}" ]] && continue
     seen[$path]=1
     backup_file "$path" "global"
-  done < <(git config --global --list --show-origin 2>/dev/null | collect_origin_paths || true)
+  done < <(git config --global --list --show-origin --includes 2>/dev/null | collect_origin_paths || true)
+  warn_gcm_in_included global "$primary"
 }
 
 print_section() {
@@ -438,11 +472,11 @@ main() {
   fi
 
   if [[ "$DO_FIX_SYSTEM" -eq 1 ]]; then
-    fix_system_helpers || exit 2
+    fix_system_helpers
   fi
 
   if [[ "$DO_MIGRATE" -eq 1 ]]; then
-    migrate_system_to_global || exit 2
+    migrate_system_to_global
   fi
 
   print_credential_section system


### PR DESCRIPTION
## Summary

- Migrated `setup-cc-gitconfig.sh` from le-git into `dev-tools/codecommit/` (initial copy retained mode via `cp -p`).
- Filled and expanded CodeCommit git setup docs; added Related link in `dev-tools/codecommit/README.md` → `./git-setup.md`. Did not touch `scripts/README.md`.

## Corrections

Script corrections pass (supersedes byte-identical requirement). **0k-aws is now the source of truth**; the script intentionally diverges from the le-git copy (le-git removal remains a separate later PR).

- **F1** — Tab-based `--show-origin` path parsing (space-safe); backups collect all distinct `file:` origins (system + global, including `[include]` targets).
- **F2** — Check-only is fully read-only: `can_write_system()` uses `-w` / ancestor-dir checks; removed `PROBE_KEY` write probe.
- **F3a** — `--fix-system` unsets only GCM helper values (anchored regex), preserving non-GCM helpers; help/docs updated.
- **F3b** — ERR trap normalizes unexpected failures to exit 2 while preserving explicit 0/1/2 paths.
- **F4** — Clarified `--migrate` actor/reload wording and aligned `--fix-system` docs with GCM-only behavior.

### Round 2 (re-audit)

- **F1 / F3b (ERR trap)** — `set -eEuo pipefail` so the ERR trap inherits into functions; removed `|| exit 2` from the two mutating call sites (`fix_system_helpers`, `migrate_system_to_global`) so `set -e` is not disabled inside them. Unexpected failures (backup mkdir/cp, unwritable global under `--migrate`, etc.) now exit 2 via the trap; no false `add:` / `Migrated` / `OK` / bashrc append on migrate failure.
- **F1 (include-aware backups)** — both origin feeds use `--includes`; backup filenames include basename so multiple same-scope origins (primary + `[include]` targets) do not overwrite; WARN when a GCM helper lives in an included file.

## Docs

- `git-setup.md` restructured into platform sections: **Windows (Git Bash)** (GCM conflict, `setup-cc-gitconfig.sh` check-only / `--fix-system` / `--migrate`, backups, exit codes, URL-scoped credential-helper manual alternative) and **Linux** (native `~/.gitconfig` credential-helper, AWS CLI/IAM notes, why HTTPS(GRC) is unnecessary, optional SSH link).
- `dev-tools/codecommit/README.md` index pass: folder contents table, tip pointing at the setup guide, related CLI notes, AWS references kept.

## Source

- [lbrealdev/le-git PR #31](https://github.com/lbrealdev/le-git/pull/31) artifacts (`git/scripts/setup-cc-gitconfig.sh`)

## Follow-up

- Removal of the script from le-git is a separate repo/PR; out of scope here.

Made with [Cursor](https://cursor.com)

Closes #42