### PR TITLE
docs(ec2): add Windows updates investigation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A personal wiki of AWS knowledge: CLI cheat sheets, operational guides, and help
 | [cli/](./cli/README.md) | AWS CLI v2 install, profile/region/pager nuances, one page per `aws` subcommand |
 | [cloudshell/](./cloudshell/README.md) | Persistent tooling (mise, just) in the CloudShell environment |
 | [cloudwatch/](./cloudwatch/README.md) | Billing alarm analysis and CloudWatch helpers |
-| [ec2/](./ec2/README.md) | Inventory, manual/final snapshots, safe elimination |
+| [ec2/](./ec2/README.md) | Inventory, manual/final snapshots, safe elimination, Windows patch-state checks |
 | [rds/](./rds/README.md) | RDS deletion considerations and checklist |
 | [list-resources/](./list-resources/README.md) | Account-wide discovery: AWS Config, Cloud Control API, CDK, Steampipe |
 | [dev-tools/](./dev-tools/README.md) | CodeCommit, CodeBuild, CodePipeline, reporting scripts |

--- a/ec2/README.md
+++ b/ec2/README.md
@@ -7,6 +7,8 @@ Operational guides and good practices for day-to-day Amazon EC2 work — invento
 - [Manual / final snapshots](./manual-snapshots.md) — when and how to take intentional EBS snapshots before risky changes
 - [EC2 Elimination](./elimination.md) — inventory, snapshots, AMIs, backups, and checklist for removing EC2 resources safely
   - Includes [Investigate recovery points](./elimination.md#investigate-recovery-points-before-adding-a-backup-filter) before adding any Backup filter
+- [Windows on EC2](./windows/README.md) — patch state on Windows Server instances
+  - [Updates](./windows/updates.md) — installed KBs, pending updates, pending reboot
 
 ## Related CLI references
 

--- a/ec2/windows/README.md
+++ b/ec2/windows/README.md
@@ -1,0 +1,12 @@
+# Windows on EC2
+
+Operational guides for Windows Server instances — patch state and related on-box checks.
+
+## Guides
+
+- [Updates](./updates.md) — installed KBs, Windows Update history, pending updates, pending reboot
+
+## Related
+
+- [Manual / final snapshots](../manual-snapshots.md) — before a patch reboot when rollback matters
+- [EC2 Elimination](../elimination.md) — inventory and teardown on the AWS side

--- a/ec2/windows/README.md
+++ b/ec2/windows/README.md
@@ -2,6 +2,8 @@
 
 Operational guides for Windows Server instances — patch state and related on-box checks.
 
+Investigation only: these guides do not install updates or reboot.
+
 ## Guides
 
 - [Updates](./updates.md) — installed KBs, Windows Update history, pending updates, pending reboot

--- a/ec2/windows/updates.md
+++ b/ec2/windows/updates.md
@@ -2,7 +2,7 @@
 
 Patch state on a Windows Server instance: what is installed, what failed, what is still waiting, and whether a reboot is pending.
 
-Run in an elevated PowerShell session on the instance.
+**Investigation only.** Run in an elevated PowerShell session on the instance. Do not install updates or reboot from this guide (`Install-WindowsUpdate`, `Add-WUPackage`, `Restart-Computer`, `shutdown /r`). Windows Update `Search()` is a query; it does not download or install.
 
 ## Why this matters
 
@@ -26,33 +26,37 @@ Get-HotFix |
   Format-Table -AutoSize
 ```
 
-One KB:
+One KB (replace the id):
 
 ```powershell
-Get-HotFix -Id KB5044284
+Get-HotFix -Id KB#########
 ```
 
 ## 3. Update history
 
 Use this when dates in `Get-HotFix` are missing or you need success/failure.
 
+`QueryHistory` is reverse chronological (most recent first). Skip the call when the log is empty — `QueryHistory(0, 0)` throws.
+
 ```powershell
 $searcher = (New-Object -ComObject Microsoft.Update.Session).CreateUpdateSearcher()
 $count = $searcher.GetTotalHistoryCount()
-$searcher.QueryHistory(0, $count) |
-  Select-Object Date, Title, @{N='Result';E={
-    switch ($_.ResultCode) {
-      2 {'Succeeded'} 3 {'SucceededWithErrors'} 4 {'Failed'} 5 {'Aborted'} default {$_.ResultCode}
-    }
-  }} |
-  Sort-Object Date -Descending |
-  Select-Object -First 30 |
-  Format-Table -AutoSize
+if ($count -eq 0) {
+  'No update history'
+} else {
+  $searcher.QueryHistory(0, [Math]::Min($count, 30)) |
+    Select-Object Date, Title, @{N='Result';E={
+      switch ($_.ResultCode) {
+        2 {'Succeeded'} 3 {'SucceededWithErrors'} 4 {'Failed'} 5 {'Aborted'} default {$_.ResultCode}
+      }
+    }} |
+    Format-Table -AutoSize
+}
 ```
 
 ## 4. Pending / available
 
-Does not install anything.
+Does not install or download anything. `Search` may take a while; it talks to Windows Update or WSUS.
 
 ```powershell
 $searcher = (New-Object -ComObject Microsoft.Update.Session).CreateUpdateSearcher()
@@ -72,11 +76,13 @@ $result.Updates | Select-Object Title | Format-Table -AutoSize
 
 ## 5. Pending reboot
 
+Read-only registry checks. Does not reboot.
+
 ```powershell
 $cbs = Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending'
 $wu  = Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired'
 $sm  = Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' -Name PendingFileRenameOperations -ErrorAction SilentlyContinue
-$pfn = $null -ne $sm.PendingFileRenameOperations
+$pfn = $null -ne $sm -and $null -ne $sm.PendingFileRenameOperations
 
 [PSCustomObject]@{
   CbsRebootPending  = $cbs
@@ -89,4 +95,4 @@ $pfn = $null -ne $sm.PendingFileRenameOperations
 ## Related
 
 - [Windows on EC2](./README.md)
-- [Manual / final snapshots](../manual-snapshots.md)
+- [Manual / final snapshots](../manual-snapshots.md) — take a snapshot before any later patch reboot when rollback matters

--- a/ec2/windows/updates.md
+++ b/ec2/windows/updates.md
@@ -1,0 +1,92 @@
+# Windows updates
+
+Patch state on a Windows Server instance: what is installed, what failed, what is still waiting, and whether a reboot is pending.
+
+Run in an elevated PowerShell session on the instance.
+
+## Why this matters
+
+- `Get-HotFix` is incomplete — `InstalledOn` is often blank; history is the install record.
+- A KB can show as installed while a reboot is still pending.
+- Pending vs downloaded-not-installed tells you whether Update is stuck or just waiting.
+
+## 1. OS and last boot
+
+```powershell
+Get-CimInstance Win32_OperatingSystem |
+  Select-Object CSName, Caption, Version, BuildNumber, LastBootUpTime
+```
+
+## 2. Installed hotfixes
+
+```powershell
+Get-HotFix |
+  Sort-Object InstalledOn -Descending |
+  Select-Object HotFixID, Description, InstalledBy, InstalledOn |
+  Format-Table -AutoSize
+```
+
+One KB:
+
+```powershell
+Get-HotFix -Id KB5044284
+```
+
+## 3. Update history
+
+Use this when dates in `Get-HotFix` are missing or you need success/failure.
+
+```powershell
+$searcher = (New-Object -ComObject Microsoft.Update.Session).CreateUpdateSearcher()
+$count = $searcher.GetTotalHistoryCount()
+$searcher.QueryHistory(0, $count) |
+  Select-Object Date, Title, @{N='Result';E={
+    switch ($_.ResultCode) {
+      2 {'Succeeded'} 3 {'SucceededWithErrors'} 4 {'Failed'} 5 {'Aborted'} default {$_.ResultCode}
+    }
+  }} |
+  Sort-Object Date -Descending |
+  Select-Object -First 30 |
+  Format-Table -AutoSize
+```
+
+## 4. Pending / available
+
+Does not install anything.
+
+```powershell
+$searcher = (New-Object -ComObject Microsoft.Update.Session).CreateUpdateSearcher()
+$result = $searcher.Search('IsInstalled=0 and IsHidden=0')
+$result.Updates |
+  Select-Object Title, IsDownloaded, MsrcSeverity, MaxDownloadSize |
+  Format-Table -AutoSize
+```
+
+Downloaded, not installed:
+
+```powershell
+$searcher = (New-Object -ComObject Microsoft.Update.Session).CreateUpdateSearcher()
+$result = $searcher.Search('IsInstalled=0 and IsDownloaded=1')
+$result.Updates | Select-Object Title | Format-Table -AutoSize
+```
+
+## 5. Pending reboot
+
+```powershell
+$cbs = Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending'
+$wu  = Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired'
+$sm  = Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' -Name PendingFileRenameOperations -ErrorAction SilentlyContinue
+$pfn = $null -ne $sm.PendingFileRenameOperations
+
+[PSCustomObject]@{
+  CbsRebootPending  = $cbs
+  WuRebootRequired  = $wu
+  PendingFileRename = [bool]$pfn
+  RebootPending     = ($cbs -or $wu -or $pfn)
+}
+```
+
+## Related
+
+- [Windows on EC2](./README.md)
+- [Manual / final snapshots](../manual-snapshots.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an EC2 operational subsection for Windows Server patch-state investigation.

- `ec2/windows/README.md` — index for Windows on-box guides
- `ec2/windows/updates.md` — installed KBs, Windows Update history, pending/available updates, pending reboot
- Linked from `ec2/README.md` Guides and the root README EC2 row

Investigation only (elevated PowerShell on the instance). No install/reboot, SSM Patch Manager, or helper scripts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01d16150-6735-49b1-a0bc-cf9efd296ee1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01d16150-6735-49b1-a0bc-cf9efd296ee1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

