### PR TITLE
docs+feat: strengthen AGENTS.md and add sg-audit / rds-snapshot-age

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,55 @@
 
 ### Scripts
 
-- Use `#!/bin/bash` and `set -euo pipefail`
+- Use `#!/bin/bash` and `set -euo pipefail` (some older helpers use `#!/usr/bin/env bash`; new scripts should follow this file)
 - Every `*.sh` must support `--help` / `-h` (print usage and exit 0)
 - `--help` / usage text must not list dependencies; check tools at runtime instead
 - Prefer read-only helpers for inventory and discovery
 - Write scripts should support `--dry-run` where practical and make side effects obvious
 - For AWS CLI scripts, prefer explicit `--profile` / `--region` over relying on shell defaults
+- Quote every expansion passed to `aws`, `jq`, and `printf`; prefer `"${array[@]}"` over unquoted extras
+- Errors and usage go to stderr; data/tables go to stdout so the output can be piped
+- Check `command -v aws` (and `jq` when used) before the first AWS call; fail with a clear message
+- When a script takes a named `--profile`, refuse `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` if those would override the profile (boto3 and some CLI chains honor env first)
+
+### Argument parsing
+
+- `while [[ $# -gt 0 ]]; do case $1 in ... esac; done` then `main` (see `auth/scripts/aws-sso-check.sh`)
+- Unknown flags: print error + usage to stderr, exit 1
+- Mutually exclusive flags should be rejected explicitly, not silently ignored
+- Keep `--help` line width at 80 columns or less
+
+### Printing and logging
+
+Config paths, profile names, and other caller/config-derived strings are untrusted for terminal output.
+
+- Do not `echo -e` (or `echo -en`) with those strings: `\n`, `\e`, `\c` and friends are interpreted even when the expansion is quoted
+- Emit data with `printf '%s'` (or `printf '%s\n'`)
+- If a line mixes trusted color tokens (`\e[32m`) with data, encode the data first so it cannot form those tokens. Doubling backslashes is not enough (`\e[31m` still matches inside `\\e`)
+- Encoding must be reversible for **any** byte, including ASCII SUB (`0x1a`). Escape existing sentinels before replacing `\`; decode in the reverse pair order. Width math must use the decoded visible string
+- Color only when stdout is a TTY (`[ -t 1 ]`); piped output stays pure text
+- Mask secrets (`AWS_SECRET_ACCESS_KEY`, session tokens): never print them in full
+
+The working example is `_esc_data` / `_unesc_data` / `_render` in `auth/scripts/aws-sso-check.sh`. Regression probe: `tests/aws-sso-check-render.sh`.
+
+### Testing
+
+There is no CI workflow yet. Before opening a PR that touches scripts:
+
+- `bash -n path/to/script.sh`
+- `shellcheck path/to/script.sh` when `shellcheck` is on `PATH` (zero findings)
+- `python3 -m py_compile path/to/script.py` for Python helpers
+- For `aws-sso-check.sh` rendering changes: `tests/aws-sso-check-render.sh` (TTY and non-TTY; includes a `0x1a` path/profile)
+- Scripts whose source is grepped for non-ASCII (token-safe renderers) must stay `LC_ALL=C grep -nP '[^\x00-\x7F]'`-clean
+
+### Docs
+
+- Each top-level area has a `README.md` index; new guides and scripts get a row or bullet there
+- Executable helpers also belong in `scripts/README.md` (or the area's `scripts/README.md`) with **read-only** vs **write**
+- Do not put credentials, account IDs from real engagements, or live dollar amounts in docs; sanitize examples
+
+### Python
+
+- Prefer a uv [inline script](https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies) (PEP 723) when third-party deps are required (`boto3`)
+- `--help` via argparse; exit 0 on help, 1 on usage, 2 on AWS errors (match `cloudwatch/scripts/` when adding there)
+- Do not log credentials or full session tokens; named profiles over implicit env

--- a/cli/security-groups.md
+++ b/cli/security-groups.md
@@ -23,3 +23,8 @@ aws ec2 describe-security-groups \
   --query "SecurityGroups[*].{Name: GroupName, IngressRules: IpPermissions[].IpRanges, EgressRules: IpPermissionsEgress[]}" \
   --output json
 ```
+
+## Related scripts
+
+- [`scripts/sg-audit.sh`](../scripts/sg-audit.sh) — read-only list of ingress rules open to `0.0.0.0/0` or `::/0`
+

--- a/rds/README.md
+++ b/rds/README.md
@@ -9,3 +9,4 @@ Operational guides for Amazon RDS.
 ## Related Scripts
 
 - [`scripts/rds-modify-snapshot.sh`](../scripts/rds-modify-snapshot.sh) — batch-modify RDS DB snapshot option groups
+- [`scripts/rds-snapshot-age.sh`](../scripts/rds-snapshot-age.sh) — read-only age report for instance and cluster snapshots

--- a/rds/deletion.md
+++ b/rds/deletion.md
@@ -108,6 +108,7 @@ aws rds delete-db-instance \
 ## Related Scripts
 
 - [`scripts/rds-modify-snapshot.sh`](../scripts/rds-modify-snapshot.sh) — batch-modify RDS DB snapshot option groups (`awsbackup` or `manual` snapshots).
+- [`scripts/rds-snapshot-age.sh`](../scripts/rds-snapshot-age.sh) — read-only age report before cleaning leftover manuals.
 
 ## References
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,12 +13,14 @@ Convention: prefer **read-only** helpers for inventory/discovery. Write helpers 
 | [`list-resources.sh`](./list-resources.sh) | Read-only | List account resources via Resource Groups Tagging API (profiles/regions, optional report) | [List Resources](../list-resources/README.md) |
 | [`s3-bucket-object.sh`](./s3-bucket-object.sh) | Read-only | List S3 buckets and object counts | [cli/s3.md](../cli/s3.md) |
 | [`rds-modify-snapshot.sh`](./rds-modify-snapshot.sh) | **Write** | Batch-modify RDS DB snapshot option groups (supports `--dry-run`) | [RDS Deletion](../rds/deletion.md), [rds/](../rds/README.md) |
+| [`sg-audit.sh`](./sg-audit.sh) | Read-only | Ingress rules open to `0.0.0.0/0` or `::/0`, with a SENSITIVE flag for watched ports | [cli/security-groups.md](../cli/security-groups.md) |
+| [`rds-snapshot-age.sh`](./rds-snapshot-age.sh) | Read-only | Instance and cluster snapshots with age in days; flag older than `--min-age` | [RDS Deletion](../rds/deletion.md), [rds/](../rds/README.md) |
 
 ## Relationships
 
 - **EC2 inventory vs final snapshots:** `ec2-inventory.sh` only reports what exists. `ec2-final-snapshot.sh` creates intentional volume snapshots and/or AMIs before a change (does not terminate or delete).
-- **RDS:** `rds-modify-snapshot.sh` changes snapshot metadata (option groups); it does not delete instances. Pair with the RDS deletion guide when planning teardown.
-- **Discovery:** `list-resources.sh` is account-wide tagging-API discovery; `ec2-inventory.sh` is deep and instance-scoped.
+- **RDS:** `rds-modify-snapshot.sh` changes snapshot metadata (option groups); it does not delete instances. Pair with the RDS deletion guide when planning teardown. `rds-snapshot-age.sh` is read-only inventory of leftover/old snapshots.
+- **Discovery:** `list-resources.sh` is account-wide tagging-API discovery; `ec2-inventory.sh` is deep and instance-scoped. `sg-audit.sh` is a narrow world-open ingress check.
 
 ## Usage notes
 

--- a/scripts/rds-snapshot-age.sh
+++ b/scripts/rds-snapshot-age.sh
@@ -1,0 +1,270 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Read-only: list RDS instance and cluster snapshots with age in days.
+
+PROFILE=""
+REGION=""
+MIN_AGE=30
+SNAPSHOT_TYPE="all"
+
+usage() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+List RDS DB and cluster snapshots with age in days (UTC). Read-only.
+Does not delete snapshots. Complements the RDS deletion checklist:
+manual snapshots persist after instance delete and incur storage cost.
+
+Rows with AGE_DAYS >= --min-age are flagged OLD=yes.
+
+Options:
+  --profile, -p NAME         AWS CLI profile
+  --region, -r REGION        AWS region
+  --min-age DAYS             Flag snapshots this old or older
+                             (default: 30)
+  --snapshot-type TYPE       automated, manual, or all
+                             (default: all)
+  --help, -h                 Show this help message
+
+EOF
+}
+
+error() { echo "[ERROR] $*" >&2; }
+info()  { echo "[INFO]  $*" >&2; }
+
+_col_width() {
+    local current="$1"
+    local value="$2"
+    local len=${#value}
+    if [ "$len" -gt "$current" ]; then
+        echo "$len"
+    else
+        echo "$current"
+    fi
+}
+
+_dashes() {
+    printf '%*s' "$1" '' | tr ' ' '-'
+}
+
+check_dependencies() {
+    if ! command -v aws >/dev/null 2>&1; then
+        error "aws CLI is not installed or not in PATH"
+        exit 2
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        error "jq is not installed or not in PATH"
+        exit 2
+    fi
+}
+
+aws_json() {
+    local -a cmd=(aws)
+    [ -n "$PROFILE" ] && cmd+=(--profile "$PROFILE")
+    [ -n "$REGION" ] && cmd+=(--region "$REGION")
+    cmd+=("$@" --output json --no-cli-pager)
+    "${cmd[@]}"
+}
+
+# ISO-8601 from AWS -> age in whole days (UTC). Empty input -> "?".
+age_days() {
+    local iso="$1"
+    local created_epoch now
+    if [ -z "$iso" ] || [ "$iso" = "null" ]; then
+        printf '%s' "?"
+        return
+    fi
+    if ! created_epoch=$(date -u -d "$iso" +%s 2>/dev/null); then
+        printf '%s' "?"
+        return
+    fi
+    now=$(date -u +%s)
+    printf '%s' "$(( (now - created_epoch) / 86400 ))"
+}
+
+print_table() {
+    local h_kind="KIND"
+    local h_id="SNAPSHOT"
+    local h_engine="ENGINE"
+    local h_type="TYPE"
+    local h_age="AGE_DAYS"
+    local h_enc="ENCRYPTED"
+    local h_old="OLD"
+    local w_kind=${#h_kind}
+    local w_id=${#h_id}
+    local w_engine=${#h_engine}
+    local w_type=${#h_type}
+    local w_age=${#h_age}
+    local w_enc=${#h_enc}
+    local w_old=${#h_old}
+    local row kind id engine stype age enc old
+
+    if [ $# -eq 0 ]; then
+        info "no snapshots"
+        return 0
+    fi
+
+    for row in "$@"; do
+        IFS=$'\t' read -r kind id engine stype age enc old <<< "$row"
+        w_kind=$(_col_width "$w_kind" "$kind")
+        w_id=$(_col_width "$w_id" "$id")
+        w_engine=$(_col_width "$w_engine" "$engine")
+        w_type=$(_col_width "$w_type" "$stype")
+        w_age=$(_col_width "$w_age" "$age")
+        w_enc=$(_col_width "$w_enc" "$enc")
+        w_old=$(_col_width "$w_old" "$old")
+    done
+
+    printf "%-*s | %-*s | %-*s | %-*s | %-*s | %-*s | %s\n" \
+        "$w_kind" "$h_kind" \
+        "$w_id" "$h_id" \
+        "$w_engine" "$h_engine" \
+        "$w_type" "$h_type" \
+        "$w_age" "$h_age" \
+        "$w_enc" "$h_enc" \
+        "$h_old"
+    printf "%s-+-%s-+-%s-+-%s-+-%s-+-%s-+-%s\n" \
+        "$(_dashes "$w_kind")" \
+        "$(_dashes "$w_id")" \
+        "$(_dashes "$w_engine")" \
+        "$(_dashes "$w_type")" \
+        "$(_dashes "$w_age")" \
+        "$(_dashes "$w_enc")" \
+        "$(_dashes "$w_old")"
+    for row in "$@"; do
+        IFS=$'\t' read -r kind id engine stype age enc old <<< "$row"
+        printf "%-*s | %-*s | %-*s | %-*s | %-*s | %-*s | %s\n" \
+            "$w_kind" "$kind" \
+            "$w_id" "$id" \
+            "$w_engine" "$engine" \
+            "$w_type" "$stype" \
+            "$w_age" "$age" \
+            "$w_enc" "$enc" \
+            "$old"
+    done
+}
+
+main() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --profile|-p)
+                if [[ -z "${2:-}" || "$2" == --* ]]; then
+                    error "Option --profile requires a value"
+                    exit 1
+                fi
+                PROFILE="$2"
+                shift 2
+                ;;
+            --region|-r)
+                if [[ -z "${2:-}" || "$2" == --* ]]; then
+                    error "Option --region requires a value"
+                    exit 1
+                fi
+                REGION="$2"
+                shift 2
+                ;;
+            --min-age)
+                if [[ -z "${2:-}" || "$2" == --* ]]; then
+                    error "Option --min-age requires a value"
+                    exit 1
+                fi
+                MIN_AGE="$2"
+                shift 2
+                ;;
+            --snapshot-type)
+                if [[ -z "${2:-}" || "$2" == --* ]]; then
+                    error "Option --snapshot-type requires a value"
+                    exit 1
+                fi
+                SNAPSHOT_TYPE="$2"
+                shift 2
+                ;;
+            --help|-h)
+                usage
+                exit 0
+                ;;
+            *)
+                error "unknown option: $1"
+                usage >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    case "$SNAPSHOT_TYPE" in
+        automated|manual|all) ;;
+        *)
+            error "--snapshot-type must be automated, manual, or all"
+            exit 1
+            ;;
+    esac
+    if ! [[ "$MIN_AGE" =~ ^[0-9]+$ ]]; then
+        error "--min-age must be a non-negative integer"
+        exit 1
+    fi
+
+    check_dependencies
+
+    local db_json cluster_json
+    if ! db_json=$(aws_json rds describe-db-snapshots); then
+        error "rds describe-db-snapshots failed"
+        exit 2
+    fi
+    if ! cluster_json=$(aws_json rds describe-db-cluster-snapshots); then
+        error "rds describe-db-cluster-snapshots failed"
+        exit 2
+    fi
+
+    local rows=()
+    local old_count=0
+    local line kind id engine stype created enc age old
+
+    while IFS=$'\t' read -r kind id engine stype created enc; do
+        [ -z "$kind" ] && continue
+        age=$(age_days "$created")
+        old="no"
+        if [[ "$age" =~ ^[0-9]+$ ]] && [ "$age" -ge "$MIN_AGE" ]; then
+            old="yes"
+            old_count=$((old_count + 1))
+        fi
+        rows+=("${kind}"$'\t'"${id}"$'\t'"${engine}"$'\t'"${stype}"$'\t'"${age}"$'\t'"${enc}"$'\t'"${old}")
+    done < <(
+        {
+            printf '%s' "$db_json" | jq -r --arg type_filter "$SNAPSHOT_TYPE" '
+                .DBSnapshots[]? as $s
+                | ($s.SnapshotType // "") as $t
+                | select(($type_filter == "all") or ($type_filter == $t))
+                | [
+                    "instance",
+                    ($s.DBSnapshotIdentifier // "-"),
+                    ($s.Engine // "-"),
+                    ($t | if . == "" then "-" else . end),
+                    ($s.SnapshotCreateTime // ""),
+                    (if $s.Encrypted == true then "yes" else "no" end)
+                  ]
+                | @tsv
+            '
+            printf '%s' "$cluster_json" | jq -r --arg type_filter "$SNAPSHOT_TYPE" '
+                .DBClusterSnapshots[]? as $s
+                | ($s.SnapshotType // "") as $t
+                | select(($type_filter == "all") or ($type_filter == $t))
+                | [
+                    "cluster",
+                    ($s.DBClusterSnapshotIdentifier // "-"),
+                    ($s.Engine // "-"),
+                    ($t | if . == "" then "-" else . end),
+                    ($s.SnapshotCreateTime // ""),
+                    (if $s.StorageEncrypted == true then "yes" else "no" end)
+                  ]
+                | @tsv
+            '
+        }
+    )
+
+    print_table "${rows[@]+"${rows[@]}"}"
+    info "snapshots: ${#rows[@]}  old (>= ${MIN_AGE}d): $old_count"
+}
+
+main "$@"

--- a/scripts/sg-audit.sh
+++ b/scripts/sg-audit.sh
@@ -1,0 +1,271 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Read-only: list security-group ingress rules that allow 0.0.0.0/0 or ::/0.
+
+PROFILE=""
+REGION=""
+PORTS_CSV="22,3389,445,3306,5432,1433,6379,27017,9200,2375,5985,5986"
+
+usage() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+List security group ingress rules open to the world (0.0.0.0/0 or
+::/0). Read-only. Does not modify groups.
+
+Every matching rule is printed. SENSITIVE=yes when the port range
+overlaps a watched port, uses all protocols, or covers all ports.
+
+Options:
+  --profile, -p NAME    AWS CLI profile
+  --region, -r REGION   AWS region
+  --ports LIST          Comma-separated watched ports
+                        (default: 22,3389,445,3306,5432,1433,6379,
+                        27017,9200,2375,5985,5986)
+  --help, -h            Show this help message
+
+EOF
+}
+
+error() { echo "[ERROR] $*" >&2; }
+info()  { echo "[INFO]  $*" >&2; }
+
+_col_width() {
+    local current="$1"
+    local value="$2"
+    local len=${#value}
+    if [ "$len" -gt "$current" ]; then
+        echo "$len"
+    else
+        echo "$current"
+    fi
+}
+
+_dashes() {
+    printf '%*s' "$1" '' | tr ' ' '-'
+}
+
+check_dependencies() {
+    if ! command -v aws >/dev/null 2>&1; then
+        error "aws CLI is not installed or not in PATH"
+        exit 2
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        error "jq is not installed or not in PATH"
+        exit 2
+    fi
+}
+
+aws_json() {
+    local -a cmd=(aws)
+    [ -n "$PROFILE" ] && cmd+=(--profile "$PROFILE")
+    [ -n "$REGION" ] && cmd+=(--region "$REGION")
+    cmd+=("$@" --output json --no-cli-pager)
+    "${cmd[@]}"
+}
+
+ports_to_label() {
+    local proto="$1"
+    local from="$2"
+    local to="$3"
+    if [ "$proto" = "-1" ]; then
+        printf '%s' "all"
+        return
+    fi
+    if [ -z "$from" ] || [ "$from" = "null" ]; then
+        from="0"
+    fi
+    if [ -z "$to" ] || [ "$to" = "null" ]; then
+        to="65535"
+    fi
+    if [ "$from" = "$to" ]; then
+        printf '%s' "$from"
+    else
+        printf '%s-%s' "$from" "$to"
+    fi
+}
+
+is_sensitive() {
+    local proto="$1"
+    local from="$2"
+    local to="$3"
+    local watched="$4"
+    local p
+    local -a watched_ports=()
+
+    if [ "$proto" = "-1" ]; then
+        return 0
+    fi
+    if [ -z "$from" ] || [ "$from" = "null" ]; then
+        from="0"
+    fi
+    if [ -z "$to" ] || [ "$to" = "null" ]; then
+        to="65535"
+    fi
+    if [ "$from" = "0" ] && [ "$to" = "65535" ]; then
+        return 0
+    fi
+    IFS=',' read -ra watched_ports <<< "$watched"
+    for p in "${watched_ports[@]}"; do
+        p="${p#"${p%%[![:space:]]*}"}"
+        p="${p%"${p##*[![:space:]]}"}"
+        [ -z "$p" ] && continue
+        [[ "$p" =~ ^[0-9]+$ ]] || continue
+        if [ "$p" -ge "$from" ] && [ "$p" -le "$to" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+print_table() {
+    local h_id="GROUP_ID"
+    local h_name="NAME"
+    local h_vpc="VPC"
+    local h_proto="PROTO"
+    local h_ports="PORTS"
+    local h_cidr="CIDR"
+    local h_sens="SENSITIVE"
+    local w_id=${#h_id}
+    local w_name=${#h_name}
+    local w_vpc=${#h_vpc}
+    local w_proto=${#h_proto}
+    local w_ports=${#h_ports}
+    local w_cidr=${#h_cidr}
+    local w_sens=${#h_sens}
+    local row id name vpc proto ports cidr sens
+
+    if [ $# -eq 0 ]; then
+        info "no world-open ingress rules"
+        return 0
+    fi
+
+    for row in "$@"; do
+        IFS=$'\t' read -r id name vpc proto ports cidr sens <<< "$row"
+        w_id=$(_col_width "$w_id" "$id")
+        w_name=$(_col_width "$w_name" "$name")
+        w_vpc=$(_col_width "$w_vpc" "$vpc")
+        w_proto=$(_col_width "$w_proto" "$proto")
+        w_ports=$(_col_width "$w_ports" "$ports")
+        w_cidr=$(_col_width "$w_cidr" "$cidr")
+        w_sens=$(_col_width "$w_sens" "$sens")
+    done
+
+    printf "%-*s | %-*s | %-*s | %-*s | %-*s | %-*s | %s\n" \
+        "$w_id" "$h_id" \
+        "$w_name" "$h_name" \
+        "$w_vpc" "$h_vpc" \
+        "$w_proto" "$h_proto" \
+        "$w_ports" "$h_ports" \
+        "$w_cidr" "$h_cidr" \
+        "$h_sens"
+    printf "%s-+-%s-+-%s-+-%s-+-%s-+-%s-+-%s\n" \
+        "$(_dashes "$w_id")" \
+        "$(_dashes "$w_name")" \
+        "$(_dashes "$w_vpc")" \
+        "$(_dashes "$w_proto")" \
+        "$(_dashes "$w_ports")" \
+        "$(_dashes "$w_cidr")" \
+        "$(_dashes "$w_sens")"
+    for row in "$@"; do
+        IFS=$'\t' read -r id name vpc proto ports cidr sens <<< "$row"
+        printf "%-*s | %-*s | %-*s | %-*s | %-*s | %-*s | %s\n" \
+            "$w_id" "$id" \
+            "$w_name" "$name" \
+            "$w_vpc" "$vpc" \
+            "$w_proto" "$proto" \
+            "$w_ports" "$ports" \
+            "$w_cidr" "$cidr" \
+            "$sens"
+    done
+}
+
+main() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --profile|-p)
+                if [[ -z "${2:-}" || "$2" == --* ]]; then
+                    error "Option --profile requires a value"
+                    exit 1
+                fi
+                PROFILE="$2"
+                shift 2
+                ;;
+            --region|-r)
+                if [[ -z "${2:-}" || "$2" == --* ]]; then
+                    error "Option --region requires a value"
+                    exit 1
+                fi
+                REGION="$2"
+                shift 2
+                ;;
+            --ports)
+                if [[ -z "${2:-}" || "$2" == --* ]]; then
+                    error "Option --ports requires a value"
+                    exit 1
+                fi
+                PORTS_CSV="$2"
+                shift 2
+                ;;
+            --help|-h)
+                usage
+                exit 0
+                ;;
+            *)
+                error "unknown option: $1"
+                usage >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    check_dependencies
+
+    local raw
+    if ! raw=$(aws_json ec2 describe-security-groups); then
+        error "ec2 describe-security-groups failed"
+        exit 2
+    fi
+
+    local line id name vpc proto from to cidr ports sens
+    local rows=()
+    local sensitive_count=0
+
+    while IFS=$'\t' read -r id name vpc proto from to cidr; do
+        [ -z "$id" ] && continue
+        ports=$(ports_to_label "$proto" "$from" "$to")
+        if is_sensitive "$proto" "$from" "$to" "$PORTS_CSV"; then
+            sens="yes"
+            sensitive_count=$((sensitive_count + 1))
+        else
+            sens="no"
+        fi
+        rows+=("${id}"$'\t'"${name}"$'\t'"${vpc}"$'\t'"${proto}"$'\t'"${ports}"$'\t'"${cidr}"$'\t'"${sens}")
+    done < <(printf '%s' "$raw" | jq -r '
+        .SecurityGroups[]? as $sg
+        | ($sg.IpPermissions // [])[]? as $p
+        | (
+            (($p.IpRanges // [])[]? | {cidr: .CidrIp}),
+            (($p.Ipv6Ranges // [])[]? | {cidr: .CidrIpv6})
+          ) as $r
+        | select($r.cidr == "0.0.0.0/0" or $r.cidr == "::/0")
+        | [
+            $sg.GroupId,
+            ($sg.GroupName // "-"),
+            ($sg.VpcId // "-"),
+            ($p.IpProtocol // "-"),
+            ($p.FromPort | if . == null then "" else tostring end),
+            ($p.ToPort | if . == null then "" else tostring end),
+            $r.cidr
+          ]
+        | @tsv
+    ')
+
+    print_table "${rows[@]+"${rows[@]}"}"
+
+    info "world-open rules: ${#rows[@]}  sensitive: $sensitive_count"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Strengthen `AGENTS.md` with argument parsing, reversible panel/log encoding (the ASCII SUB lesson from #47), testing gates, docs/Python norms — matching how this repo actually writes scripts.
- Add two read-only helpers (quality over quantity; not a sweep of every audit idea):
  - `scripts/sg-audit.sh` — ingress `0.0.0.0/0` / `::/0`, SENSITIVE flag for watched ports / all-protocol / all-ports
  - `scripts/rds-snapshot-age.sh` — instance + cluster snapshot age; `OLD=yes` at `--min-age` (default 30d)
- Wire them into `scripts/README.md`, `rds/`, and `cli/security-groups.md`.

Not implemented here (already covered or lower leverage): SSO session health (`aws-sso-check.sh`), billing spikes (PR #48), IAM role search (`feat/find-iam-role` already on a branch).

## Test plan
- [x] `bash -n scripts/sg-audit.sh scripts/rds-snapshot-age.sh`
- [x] `--help` / `-h` exit 0; max line width 66 / 70
- [x] unknown flags and bad `--snapshot-type` / `--min-age` exit 1
- [x] jq fixture: world-open SSH + all-protocol IPv4/IPv6 listed; private 443 omitted
- [x] missing `aws` exits 2 (tools checked at runtime, not in `--help`)
- [ ] `shellcheck` when the binary is available (not installed on this runner)
- [ ] Live `--profile` / `--region` against a real account